### PR TITLE
Add ECS and PHPStan tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: ecs phpstan prepush
+
+ecs:
+	vendor/bin/ecs check
+
+phpstan:
+	vendor/bin/phpstan analyse -c phpstan.neon
+
+prepush: ecs phpstan

--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,9 @@
         "post-update-cmd": [
             "@auto-scripts"
         ],
-        "pre-autoload-dump": "Google\\Task\\Composer::cleanup"
+        "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
+        "ecs": "vendor/bin/ecs check",
+        "phpstan": "vendor/bin/phpstan analyse -c phpstan.neon"
     },
     "conflict": {
         "symfony/symfony": "*"
@@ -128,6 +130,8 @@
         "symfony/maker-bundle": "^1.0",
         "symfony/phpunit-bridge": "^7.2",
         "symfony/stopwatch": "7.2.*",
-        "symfony/web-profiler-bundle": "7.2.*"
+        "symfony/web-profiler-bundle": "7.2.*",
+        "symplify/easy-coding-standard": "^12.5",
+        "phpstan/phpstan": "^2.1"
     }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return static function (ECSConfig $config): void {
+    $config->paths([__DIR__ . '/src']);
+    $config->sets([
+        Symplify\EasyCodingStandard\ValueObject\Set\SetList::PSR_12,
+    ]);
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 1
+    paths:
+        - src


### PR DESCRIPTION
## Summary
- add basic phpstan and ECS to dev dependencies
- expose ecs and phpstan scripts through composer
- create ECS and PHPStan configuration files
- add Makefile with `prepush` rule to run code quality checks

## Testing
- `make prepush` *(fails: vendor/bin/ecs missing)*

------
https://chatgpt.com/codex/tasks/task_e_68406f52c6848326904079351bcbf052