### PR TITLE
Move larp relation to base StoryObject

### DIFF
--- a/migrations/Version20250512000000.php
+++ b/migrations/Version20250512000000.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250512000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Move larp_id from sub tables to story_object';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE story_object ADD larp_id UUID DEFAULT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN story_object.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = e.larp_id FROM event e WHERE e.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = i.larp_id FROM item i WHERE i.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = lc.larp_id FROM larp_character lc WHERE lc.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = lf.larp_id FROM larp_faction lf WHERE lf.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = q.larp_id FROM quest q WHERE q.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = r.larp_id FROM relation r WHERE r.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE story_object s SET larp_id = t.larp_id FROM thread t WHERE t.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE story_object ALTER COLUMN larp_id SET NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE story_object ADD CONSTRAINT FK_E7AE191E63FF2A01 FOREIGN KEY (larp_id) REFERENCES larp (id) NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IDX_E7AE191E63FF2A01 ON story_object (larp_id)
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event DROP CONSTRAINT IF EXISTS FK_3BAE0AA763FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE item DROP CONSTRAINT IF EXISTS FK_1F1B251E63FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_character DROP CONSTRAINT IF EXISTS FK_AFC950DF63FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_faction DROP CONSTRAINT IF EXISTS FK_57A68DEA63FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest DROP CONSTRAINT IF EXISTS FK_4317F81763FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE relation DROP CONSTRAINT IF EXISTS FK_6289474963FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread DROP CONSTRAINT IF EXISTS FK_31204C8363FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event DROP larp_id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE item DROP larp_id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_character DROP larp_id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_faction DROP larp_id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest DROP larp_id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE relation DROP larp_id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread DROP larp_id
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE item ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_character ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_faction ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE relation ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread ADD larp_id UUID NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN event.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN item.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN larp_character.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN larp_faction.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN quest.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN relation.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN thread.larp_id IS '(DC2Type:uuid)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE event e SET larp_id = s.larp_id FROM story_object s WHERE e.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE item i SET larp_id = s.larp_id FROM story_object s WHERE i.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE larp_character lc SET larp_id = s.larp_id FROM story_object s WHERE lc.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE larp_faction lf SET larp_id = s.larp_id FROM story_object s WHERE lf.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE quest q SET larp_id = s.larp_id FROM story_object s WHERE q.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE relation r SET larp_id = s.larp_id FROM story_object s WHERE r.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE thread t SET larp_id = s.larp_id FROM story_object s WHERE t.id = s.id
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE story_object DROP CONSTRAINT FK_E7AE191E63FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP INDEX IDX_E7AE191E63FF2A01
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE story_object DROP larp_id
+        SQL);
+    }
+}

--- a/src/Entity/StoryObject/Event.php
+++ b/src/Entity/StoryObject/Event.php
@@ -4,7 +4,6 @@ namespace App\Entity\StoryObject;
 
 
 use App\Entity\Enum\StoryTimeUnit;
-use App\Entity\Larp;
 use App\Entity\LarpParticipant;
 use App\Repository\StoryObject\EventRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -16,9 +15,6 @@ use App\Entity\Enum\TargetType;
 class Event extends StoryObject
 {
 
-    #[ORM\ManyToOne(targetEntity: Larp::class, inversedBy: 'events')]
-    #[ORM\JoinColumn(nullable: false)]
-    protected Larp $larp;
 
     /** @var Collection<LarpParticipant> Participants (technical) needed for event to happen */
     #[ORM\ManyToMany(targetEntity: LarpParticipant::class)]
@@ -155,15 +151,6 @@ class Event extends StoryObject
         $this->storyTimeUnit = $storyTimeUnit;
     }
 
-    public function getLarp(): Larp
-    {
-        return $this->larp;
-    }
-
-    public function setLarp(Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
 
     public static function getTargetType(): TargetType
     {

--- a/src/Entity/StoryObject/Item.php
+++ b/src/Entity/StoryObject/Item.php
@@ -3,7 +3,6 @@
 namespace App\Entity\StoryObject;
 
 use App\Entity\Enum\TargetType;
-use App\Entity\Larp;
 use App\Repository\StoryObject\ItemRepository;
 use Money\Money;
 use Doctrine\ORM\Mapping as ORM;
@@ -13,9 +12,6 @@ use Doctrine\ORM\Mapping\Embedded;
 class Item extends StoryObject
 {
 
-    #[ORM\ManyToOne(targetEntity: Larp::class)]
-    #[ORM\JoinColumn(nullable: false)]
-    protected ?Larp $larp;
 
     /** @var StoryObject|null The item can be for specific quest, thread, character, faction */
     #[ORM\ManyToMany(targetEntity: StoryObject::class)]
@@ -34,15 +30,6 @@ class Item extends StoryObject
     #[Embedded]
     private Money $cost;
 
-    public function getLarp(): ?Larp
-    {
-        return $this->larp;
-    }
-
-    public function setLarp(?Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
 
     public function isCrafted(): bool
     {

--- a/src/Entity/StoryObject/LarpCharacter.php
+++ b/src/Entity/StoryObject/LarpCharacter.php
@@ -22,7 +22,6 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
     fields: ['larp', 'title'],
     message: 'A character with this title already exists in this LARP.'
 )]
-#[ORM\Index(columns: ['larp_id'])]
 #[ORM\Index(columns: ['in_game_name'])]
 #[ORM\Entity(repositoryClass: LarpCharacterRepository::class)]
 class LarpCharacter extends StoryObject
@@ -30,9 +29,6 @@ class LarpCharacter extends StoryObject
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $inGameName = null;
 
-    #[ORM\ManyToOne(targetEntity: Larp::class, inversedBy: 'characters')]
-    #[ORM\JoinColumn(nullable: false)]
-    protected ?Larp $larp = null;
 
     #[ORM\OneToOne(targetEntity: self::class, fetch: 'EXTRA_LAZY')]
     #[ORM\JoinColumn(name: "previous_character_id", referencedColumnName: "id", nullable: true)]
@@ -94,15 +90,6 @@ class LarpCharacter extends StoryObject
         $this->characterType = CharacterType::Player;
     }
 
-    public function getLarp(): ?Larp
-    {
-        return $this->larp;
-    }
-
-    public function setLarp(?Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
 
     public function addThread(Thread $thread): self
     {

--- a/src/Entity/StoryObject/LarpFaction.php
+++ b/src/Entity/StoryObject/LarpFaction.php
@@ -3,7 +3,6 @@
 namespace App\Entity\StoryObject;
 
 use App\Entity\Enum\TargetType;
-use App\Entity\Larp;
 use App\Entity\Trait\CreatorAwareInterface;
 use App\Repository\StoryObject\LarpFactionRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -13,8 +12,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: LarpFactionRepository::class)]
 class LarpFaction extends StoryObject implements CreatorAwareInterface
 {
-    #[ORM\ManyToOne(targetEntity: Larp::class, inversedBy: 'factions')]
-    private ?Larp $larp;
 
     #[ORM\ManyToMany(targetEntity: LarpCharacter::class, mappedBy: 'factions')]
     private Collection $members;
@@ -92,10 +89,6 @@ class LarpFaction extends StoryObject implements CreatorAwareInterface
         return TargetType::Faction;
     }
 
-    public function getLarp(): ?Larp
-    {
-        return $this->larp;
-    }
 
     public function getQuests(): Collection
     {
@@ -117,9 +110,4 @@ class LarpFaction extends StoryObject implements CreatorAwareInterface
         $this->threads = $threads;
     }
 
-    public function setLarp(?Larp $larp): void
-    {
-        $this->larp = $larp;
-        $larp->addFaction($this);
-    }
 }

--- a/src/Entity/StoryObject/Place.php
+++ b/src/Entity/StoryObject/Place.php
@@ -11,24 +11,12 @@ use App\Entity\Enum\TargetType;
 class Place extends StoryObject
 {
 
-    #[ORM\ManyToOne(targetEntity: Larp::class, inversedBy: 'places')]
-    #[ORM\JoinColumn(nullable: false)]
-    protected Larp $larp;
     
     public function __construct()
     {
         parent::__construct();
     }
 
-    public function getLarp(): Larp
-    {
-        return $this->larp;
-    }
-
-    public function setLarp(Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
 
     public static function getTargetType(): TargetType
     {

--- a/src/Entity/StoryObject/Quest.php
+++ b/src/Entity/StoryObject/Quest.php
@@ -15,9 +15,6 @@ use App\Entity\Enum\TargetType;
 class Quest extends StoryObject
 {
 
-    #[ORM\ManyToOne(targetEntity: Larp::class)]
-    #[ORM\JoinColumn(nullable: false)]
-    protected ?Larp $larp;
 
     #[ORM\ManyToOne(targetEntity: Thread::class, inversedBy: 'quests')]
     #[ORM\JoinColumn(nullable: true)]
@@ -100,15 +97,6 @@ class Quest extends StoryObject
         $this->involvedFactions = $involvedFactions;
     }
 
-    public function setLarp(?Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
-
-    public function getLarp(): ?Larp
-    {
-        return $this->larp;
-    }
 
     public static function getTargetType(): TargetType
     {

--- a/src/Entity/StoryObject/Relation.php
+++ b/src/Entity/StoryObject/Relation.php
@@ -11,9 +11,6 @@ use App\Entity\Enum\TargetType;
 class Relation extends StoryObject
 {
 
-    #[ORM\ManyToOne(targetEntity: Larp::class)]
-    #[ORM\JoinColumn(nullable: false)]
-    protected ?Larp $larp = null;
 
     #[ORM\ManyToOne(targetEntity: StoryObject::class)]
     #[ORM\JoinColumn(nullable: false)]
@@ -26,15 +23,6 @@ class Relation extends StoryObject
     private ?TargetType $fromType = null;
     private ?TargetType $toType = null;
 
-    public function getLarp(): ?Larp
-    {
-        return $this->larp;
-    }
-
-    public function setLarp(?Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
 
     public function getFrom(): ?StoryObject
     {

--- a/src/Entity/StoryObject/StoryObject.php
+++ b/src/Entity/StoryObject/StoryObject.php
@@ -20,6 +20,7 @@ use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: StoryObjectRepository::class)]
 #[ORM\Index(columns: ['title'])]
+#[ORM\Index(columns: ['larp_id'])]
 #[ORM\InheritanceType('JOINED')]
 #[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
 #[ORM\DiscriminatorMap([
@@ -48,6 +49,10 @@ abstract class StoryObject implements CreatorAwareInterface, Timestampable, Targ
 
     #[ORM\Column(type: 'text', nullable: true)]
     protected ?string $description = null;
+
+    #[ORM\ManyToOne(targetEntity: Larp::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    protected ?Larp $larp = null;
 
     /** @var Collection<ExternalReference>  */
     #[ORM\OneToMany(targetEntity: ExternalReference::class, mappedBy: 'storyObject', cascade: ['persist', 'remove'], orphanRemoval: true)]
@@ -86,6 +91,16 @@ abstract class StoryObject implements CreatorAwareInterface, Timestampable, Targ
     {
         $this->description = $description;
         return $this;
+    }
+
+    public function getLarp(): ?Larp
+    {
+        return $this->larp;
+    }
+
+    public function setLarp(?Larp $larp): void
+    {
+        $this->larp = $larp;
     }
 
     public function getExternalReferences(): Collection

--- a/src/Entity/StoryObject/Thread.php
+++ b/src/Entity/StoryObject/Thread.php
@@ -14,9 +14,6 @@ use App\Entity\Enum\TargetType;
 class Thread extends StoryObject
 {
 
-    #[ORM\ManyToOne(targetEntity: Larp::class)]
-    #[ORM\JoinColumn(nullable: false)]
-    protected ?Larp $larp;
 
     /** @var Collection<Quest> */
     #[ORM\OneToMany(targetEntity: Quest::class, mappedBy: 'thread')]
@@ -95,15 +92,6 @@ class Thread extends StoryObject
         $this->involvedFactions = $involvedFactions;
     }
 
-    public function getLarp(): ?Larp
-    {
-        return $this->larp;
-    }
-
-    public function setLarp(?Larp $larp): void
-    {
-        $this->larp = $larp;
-    }
 
     public function getQuests(): Collection
     {


### PR DESCRIPTION
## Summary
- centralize `larp` relation in `StoryObject`
- remove duplicated `larp` properties and methods from story object subclasses
- add migration moving `larp_id` columns to `story_object`

## Testing
- `composer ecs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434850e1b0832691cb3807f0469581