### PR TITLE
Add CRUD for place and item story objects

### DIFF
--- a/src/Controller/Backoffice/Story/ItemController.php
+++ b/src/Controller/Backoffice/Story/ItemController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Controller\Backoffice\Story;
+
+use App\Controller\BaseController;
+use App\Entity\Larp;
+use App\Entity\StoryObject\Item;
+use App\Form\Filter\ItemFilterType;
+use App\Form\ItemType;
+use App\Helper\Logger;
+use App\Repository\StoryObject\ItemRepository;
+use Money\Currency;
+use Money\Money;
+use App\Service\Integrations\IntegrationManager;
+use App\Service\Larp\LarpManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/larp/{larp}/story/item/', name: 'backoffice_larp_story_item_')]
+class ItemController extends BaseController
+{
+    #[Route('list', name: 'list', methods: ['GET', 'POST'])]
+    public function list(Request $request, Larp $larp, ItemRepository $repository): Response
+    {
+        $filterForm = $this->createForm(ItemFilterType::class);
+        $filterForm->handleRequest($request);
+        $qb = $repository->createQueryBuilder('c');
+        $this->filterBuilderUpdater->addFilterConditions($filterForm, $qb);
+        $sort = $request->query->get('sort', 'title');
+        $dir = $request->query->get('dir', 'asc');
+        $qb->orderBy('c.' . $sort, $dir);
+        $qb->andWhere('c.larp = :larp')->setParameter('larp', $larp);
+
+        return $this->render('backoffice/larp/item/list.html.twig', [
+            'filterForm' => $filterForm->createView(),
+            'items' => $qb->getQuery()->getResult(),
+            'larp' => $larp,
+        ]);
+    }
+
+    #[Route('{item}', name: 'modify', defaults: ['item' => null], methods: ['GET', 'POST'])]
+    public function modify(
+        LarpManager $larpManager,
+        IntegrationManager $integrationManager,
+        Request $request,
+        Larp $larp,
+        ItemRepository $itemRepository,
+        ?Item $item = null,
+    ): Response {
+        $new = false;
+        if (!$item) {
+            $item = new Item();
+            $item->setLarp($larp);
+            $item->setCost(new Money(0, new Currency('USD')));
+            $new = true;
+        }
+
+        $form = $this->createForm(ItemType::class, $item, ['larp' => $larp]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $itemRepository->save($item);
+            $this->processIntegrationsForStoryObject($larpManager, $larp, $integrationManager, $new, $item);
+            $this->addFlash('success', $this->translator->trans('backoffice.common.success_save'));
+            return $this->redirectToRoute('backoffice_larp_story_item_list', ['larp' => $larp->getId()]);
+        }
+
+        return $this->render('backoffice/larp/item/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
+            'item' => $item,
+        ]);
+    }
+
+    #[Route('{item}/delete', name: 'delete', methods: ['GET', 'POST'])]
+    public function delete(
+        LarpManager $larpManager,
+        IntegrationManager $integrationManager,
+        Larp $larp,
+        Request $request,
+        ItemRepository $itemRepository,
+        Item $item,
+    ): Response {
+        $deleteIntegrations = $request->query->getBoolean('integrations');
+        if ($deleteIntegrations) {
+            $integrations = $larpManager->getIntegrationsForLarp($larp);
+            foreach ($integrations as $integration) {
+                try {
+                    $integrationService = $integrationManager->getService($integration);
+                    $integrationService->removeStoryObject($integration, $item);
+                } catch (\Throwable $e) {
+                    Logger::get()->error($e->getMessage(), $e->getTrace());
+                    $this->addFlash('danger', 'Failed to remove from ' . $integration->getProvider()->name . '. Item not deleted.');
+                    return $this->redirectToRoute('backoffice_larp_story_item_list', [ 'larp' => $larp->getId() ]);
+                }
+            }
+        }
+
+        $itemRepository->remove($item);
+        $this->addFlash('success', $this->translator->trans('backoffice.common.success_delete'));
+        return $this->redirectToRoute('backoffice_larp_story_item_list', ['larp' => $larp->getId()]);
+    }
+
+    #[Route('import/file', name: 'import_file', methods: ['GET', 'POST'])]
+    public function importFile(Larp $larp, LarpManager $larpManager): Response
+    {
+        return new Response('TODO:: Import from file csv/xlsx');
+    }
+}

--- a/src/Controller/Backoffice/Story/PlaceController.php
+++ b/src/Controller/Backoffice/Story/PlaceController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Controller\Backoffice\Story;
+
+use App\Controller\BaseController;
+use App\Entity\Larp;
+use App\Entity\StoryObject\Place;
+use App\Form\Filter\PlaceFilterType;
+use App\Form\PlaceType;
+use App\Helper\Logger;
+use App\Repository\StoryObject\PlaceRepository;
+use App\Service\Integrations\IntegrationManager;
+use App\Service\Larp\LarpManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/larp/{larp}/story/place/', name: 'backoffice_larp_story_place_')]
+class PlaceController extends BaseController
+{
+    #[Route('list', name: 'list', methods: ['GET', 'POST'])]
+    public function list(Request $request, Larp $larp, PlaceRepository $repository): Response
+    {
+        $filterForm = $this->createForm(PlaceFilterType::class);
+        $filterForm->handleRequest($request);
+        $qb = $repository->createQueryBuilder('c');
+        $this->filterBuilderUpdater->addFilterConditions($filterForm, $qb);
+        $sort = $request->query->get('sort', 'title');
+        $dir = $request->query->get('dir', 'asc');
+        $qb->orderBy('c.' . $sort, $dir);
+        $qb->andWhere('c.larp = :larp')->setParameter('larp', $larp);
+
+        return $this->render('backoffice/larp/place/list.html.twig', [
+            'filterForm' => $filterForm->createView(),
+            'places' => $qb->getQuery()->getResult(),
+            'larp' => $larp,
+        ]);
+    }
+
+    #[Route('{place}', name: 'modify', defaults: ['place' => null], methods: ['GET', 'POST'])]
+    public function modify(
+        LarpManager $larpManager,
+        IntegrationManager $integrationManager,
+        Request $request,
+        Larp $larp,
+        PlaceRepository $placeRepository,
+        ?Place $place = null,
+    ): Response {
+        $new = false;
+        if (!$place) {
+            $place = new Place();
+            $place->setLarp($larp);
+            $new = true;
+        }
+
+        $form = $this->createForm(PlaceType::class, $place, ['larp' => $larp]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $placeRepository->save($place);
+            $this->processIntegrationsForStoryObject($larpManager, $larp, $integrationManager, $new, $place);
+            $this->addFlash('success', $this->translator->trans('backoffice.common.success_save'));
+            return $this->redirectToRoute('backoffice_larp_story_place_list', ['larp' => $larp->getId()]);
+        }
+
+        return $this->render('backoffice/larp/place/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
+            'place' => $place,
+        ]);
+    }
+
+    #[Route('{place}/delete', name: 'delete', methods: ['GET', 'POST'])]
+    public function delete(
+        LarpManager $larpManager,
+        IntegrationManager $integrationManager,
+        Larp $larp,
+        Request $request,
+        PlaceRepository $placeRepository,
+        Place $place,
+    ): Response {
+        $deleteIntegrations = $request->query->getBoolean('integrations');
+        if ($deleteIntegrations) {
+            $integrations = $larpManager->getIntegrationsForLarp($larp);
+            foreach ($integrations as $integration) {
+                try {
+                    $integrationService = $integrationManager->getService($integration);
+                    $integrationService->removeStoryObject($integration, $place);
+                } catch (\Throwable $e) {
+                    Logger::get()->error($e->getMessage(), $e->getTrace());
+                    $this->addFlash('danger', 'Failed to remove from ' . $integration->getProvider()->name . '. Place not deleted.');
+                    return $this->redirectToRoute('backoffice_larp_story_place_list', [ 'larp' => $larp->getId() ]);
+                }
+            }
+        }
+
+        $placeRepository->remove($place);
+        $this->addFlash('success', $this->translator->trans('backoffice.common.success_delete'));
+        return $this->redirectToRoute('backoffice_larp_story_place_list', ['larp' => $larp->getId()]);
+    }
+
+    #[Route('import/file', name: 'import_file', methods: ['GET', 'POST'])]
+    public function importFile(Larp $larp, LarpManager $larpManager): Response
+    {
+        return new Response('TODO:: Import from file csv/xlsx');
+    }
+}

--- a/src/Form/Filter/ItemFilterType.php
+++ b/src/Form/Filter/ItemFilterType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Form\Filter;
+
+use Spiriit\Bundle\FormFilterBundle\Filter\FilterOperands;
+use Spiriit\Bundle\FormFilterBundle\Filter\Form\Type as Filters;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ItemFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', Filters\TextFilterType::class, [
+                'condition_pattern' => FilterOperands::STRING_CONTAINS,
+            ])
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'larp_item_filter';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'validation_groups' => ['filtering'],
+            'method' => 'GET',
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Form/Filter/PlaceFilterType.php
+++ b/src/Form/Filter/PlaceFilterType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Form\Filter;
+
+use Spiriit\Bundle\FormFilterBundle\Filter\FilterOperands;
+use Spiriit\Bundle\FormFilterBundle\Filter\Form\Type as Filters;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PlaceFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', Filters\TextFilterType::class, [
+                'condition_pattern' => FilterOperands::STRING_CONTAINS,
+            ])
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'larp_place_filter';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'validation_groups' => ['filtering'],
+            'method' => 'GET',
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Form/ItemType.php
+++ b/src/Form/ItemType.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Larp;
+use App\Entity\StoryObject\Item;
+use Money\Currency;
+use Money\Money;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Yceruto\MoneyBundle\Form\Type\MoneyType;
+
+class ItemType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'form.item.name',
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'form.item.description',
+                'required' => false,
+            ])
+            ->add('isCrafted', CheckboxType::class, [
+                'label' => 'form.item.is_crafted',
+                'required' => false,
+            ])
+            ->add('isPurchased', CheckboxType::class, [
+                'label' => 'form.item.is_purchased',
+                'required' => false,
+            ])
+            ->add('quantity', IntegerType::class, [
+                'label' => 'form.item.quantity',
+            ])
+            ->add('cost', MoneyType::class, [
+                'label' => 'form.item.cost',
+                'currency' => 'USD',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.submit',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Item::class,
+            'translation_domain' => 'forms',
+            'larp' => null,
+        ]);
+
+        $resolver->setRequired('larp');
+        $resolver->setAllowedTypes('larp', Larp::class);
+    }
+}

--- a/src/Form/PlaceType.php
+++ b/src/Form/PlaceType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Larp;
+use App\Entity\StoryObject\Place;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PlaceType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'form.place.name',
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'form.place.description',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.submit',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Place::class,
+            'translation_domain' => 'forms',
+            'larp' => null,
+        ]);
+
+        $resolver->setRequired('larp');
+        $resolver->setAllowedTypes('larp', Larp::class);
+    }
+}

--- a/templates/backoffice/larp/_menu.html.twig
+++ b/templates/backoffice/larp/_menu.html.twig
@@ -76,6 +76,16 @@
                            class="btn btn-primary {% if 'larp_story_event' in currentRoute %}active{% endif %}">
                             {{ 'backoffice.larp.events'|trans }}
                         </a>
+
+                        <a href="{{ path('backoffice_larp_story_place_list', {'larp': larp.id}) }}"
+                           class="btn btn-primary {% if 'larp_story_place' in currentRoute %}active{% endif %}">
+                            {{ 'backoffice.larp.place.list'|trans }}
+                        </a>
+
+                        <a href="{{ path('backoffice_larp_story_item_list', {'larp': larp.id}) }}"
+                           class="btn btn-primary {% if 'larp_story_item' in currentRoute %}active{% endif %}">
+                            {{ 'backoffice.larp.item.list'|trans }}
+                        </a>
                     </div>
                 {% endif %}
             </div>

--- a/templates/backoffice/larp/item/list.html.twig
+++ b/templates/backoffice/larp/item/list.html.twig
@@ -1,0 +1,85 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <div class="card mt-4">
+        <div class="card-header">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="mb-0">{{ 'backoffice.larp.item.list'|trans }}</h2>
+                <div class="d-flex gap-2">
+                    <a href="{{ path('backoffice_larp_story_item_modify', { larp: larp.id }) }}" class="btn btn-success">
+                        {{ 'common.create'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="card-body p-0">
+            {% include 'includes/filter_form.html.twig' with { form: filterForm } %}
+
+            <table class="table table-striped table-hover mb-0">
+                <thead class="table-light">
+                <tr>
+                    {% include 'includes/sort_th.html.twig' with {
+                        field: 'title',
+                        label: 'common.name'|trans
+                    } %}
+                    <th>{{ 'common.description'|trans }}</th>
+                    <th>{{ 'common.actions'|trans }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for item in items %}
+                    <tr>
+                        <td>{{ item.title }}</td>
+                        <td>{{ item.description|default('-') }}</td>
+                        <td>
+                            <a href="{{ path('backoffice_larp_story_item_modify', { larp: larp.id, item: item.id }) }}" class="btn btn-sm btn-primary">
+                                {{ 'common.show_edit'|trans }}
+                            </a>
+                            <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#globalDeleteItemModal" data-delete-text=" {{ 'common.delete'|trans }}" data-character-id="{{ item.id }}" data-character-name="{{ item.title }}" data-delete-url-base="{{ path('backoffice_larp_story_item_delete', { larp: larp.id, item: 'CHARACTER_ID' }) }}">
+                                {{ 'common.delete'|trans }}
+                            </button>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="modal fade" id="globalDeleteItemModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="globalDeleteItemModalLabel"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'common.close'|trans }}"></button>
+                </div>
+                <div class="modal-body">
+                    {{ 'backoffice.common.confirmation'|trans() }}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        {{ 'common.cancel'|trans }}
+                    </button>
+                    <a href="#" id="deleteOnlyLarpilot" class="btn btn-danger">
+                        {{ 'backoffice.larp.item.delete_only_larpilot'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const deleteModal = document.getElementById('globalDeleteItemModal');
+        deleteModal.addEventListener('show.bs.modal', function (event) {
+            const button = event.relatedTarget;
+            const characterId = button.getAttribute('data-character-id');
+            const characterName = button.getAttribute('data-character-name');
+            const baseUrl = button.getAttribute('data-delete-url-base');
+            const deleteTxt = button.getAttribute('data-delete-text');
+            const modalTitle = deleteModal.querySelector('.modal-title');
+            modalTitle.textContent = `${deleteTxt} "${characterName}"?`;
+            const deleteOnlyLink = document.getElementById('deleteOnlyLarpilot');
+            deleteOnlyLink.href = baseUrl.replace('CHARACTER_ID', characterId).replace('INTEGRATIONS_FLAG', 'false');
+        });
+    </script>
+{% endblock %}

--- a/templates/backoffice/larp/item/modify.html.twig
+++ b/templates/backoffice/larp/item/modify.html.twig
@@ -1,0 +1,11 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <div>
+        {{ form_start(form) }}
+        {{ form_widget(form) }}
+        {{ form_end(form) }}
+    </div>
+{% endblock %}
+
+{% block title %}{{ ''|trans }}{% endblock %}

--- a/templates/backoffice/larp/place/list.html.twig
+++ b/templates/backoffice/larp/place/list.html.twig
@@ -1,0 +1,85 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <div class="card mt-4">
+        <div class="card-header">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="mb-0">{{ 'backoffice.larp.place.list'|trans }}</h2>
+                <div class="d-flex gap-2">
+                    <a href="{{ path('backoffice_larp_story_place_modify', { larp: larp.id }) }}" class="btn btn-success">
+                        {{ 'common.create'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="card-body p-0">
+            {% include 'includes/filter_form.html.twig' with { form: filterForm } %}
+
+            <table class="table table-striped table-hover mb-0">
+                <thead class="table-light">
+                <tr>
+                    {% include 'includes/sort_th.html.twig' with {
+                        field: 'title',
+                        label: 'common.name'|trans
+                    } %}
+                    <th>{{ 'common.description'|trans }}</th>
+                    <th>{{ 'common.actions'|trans }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for place in places %}
+                    <tr>
+                        <td>{{ place.title }}</td>
+                        <td>{{ place.description|default('-') }}</td>
+                        <td>
+                            <a href="{{ path('backoffice_larp_story_place_modify', { larp: larp.id, place: place.id }) }}" class="btn btn-sm btn-primary">
+                                {{ 'common.show_edit'|trans }}
+                            </a>
+                            <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#globalDeletePlaceModal" data-delete-text=" {{ 'common.delete'|trans }}" data-character-id="{{ place.id }}" data-character-name="{{ place.title }}" data-delete-url-base="{{ path('backoffice_larp_story_place_delete', { larp: larp.id, place: 'CHARACTER_ID' }) }}">
+                                {{ 'common.delete'|trans }}
+                            </button>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="modal fade" id="globalDeletePlaceModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="globalDeletePlaceModalLabel"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'common.close'|trans }}"></button>
+                </div>
+                <div class="modal-body">
+                    {{ 'backoffice.common.confirmation'|trans() }}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        {{ 'common.cancel'|trans }}
+                    </button>
+                    <a href="#" id="deleteOnlyLarpilot" class="btn btn-danger">
+                        {{ 'backoffice.larp.place.delete_only_larpilot'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const deleteModal = document.getElementById('globalDeletePlaceModal');
+        deleteModal.addEventListener('show.bs.modal', function (event) {
+            const button = event.relatedTarget;
+            const characterId = button.getAttribute('data-character-id');
+            const characterName = button.getAttribute('data-character-name');
+            const baseUrl = button.getAttribute('data-delete-url-base');
+            const deleteTxt = button.getAttribute('data-delete-text');
+            const modalTitle = deleteModal.querySelector('.modal-title');
+            modalTitle.textContent = `${deleteTxt} "${characterName}"?`;
+            const deleteOnlyLink = document.getElementById('deleteOnlyLarpilot');
+            deleteOnlyLink.href = baseUrl.replace('CHARACTER_ID', characterId).replace('INTEGRATIONS_FLAG', 'false');
+        });
+    </script>
+{% endblock %}

--- a/templates/backoffice/larp/place/modify.html.twig
+++ b/templates/backoffice/larp/place/modify.html.twig
@@ -1,0 +1,11 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <div>
+        {{ form_start(form) }}
+        {{ form_widget(form) }}
+        {{ form_end(form) }}
+    </div>
+{% endblock %}
+
+{% block title %}{{ ''|trans }}{% endblock %}

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -55,3 +55,13 @@ form:
     mapping_type: "Mapping Type"
     reference_type: "Type"
     url: "URL"
+  place:
+    name: "Unique Place Name"
+    description: "Place Description"
+  item:
+    name: "Unique Item Name"
+    description: "Item Description"
+    is_crafted: "Crafted"
+    is_purchased: "Purchased"
+    quantity: "Quantity"
+    cost: "Cost"


### PR DESCRIPTION
## Summary
- implement `PlaceType` and `ItemType` form classes
- add filter forms for places and items
- create controllers for new story objects
- provide twig templates for listing and editing items/places
- show menu entries for items and places
- extend form translations for new types

## Testing
- `make prepush` *(fails: vendor/bin/ecs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f807d3b88326a9a8f4c77ec70689