### PR TITLE
Add decision tree Stimulus controller

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -5,6 +5,7 @@ import Folder_browser_controller from "./controllers/integrations/folder_browser
 import GoogleFilePickerController from "./controllers/integrations/google_file_picker_controller.js";
 import CustomAutocompleteController from "./controllers/custom-autocomplete_controller.js";
 import StoryGraphController from "./controllers/story_graph_controller.js";
+import DecisionTreeController from "./controllers/decision_tree_controller.js";
 
 const app = startStimulusApp();
 app.register('live', LiveController);
@@ -12,3 +13,4 @@ app.register('folder-browser', Folder_browser_controller);
 app.register("google-file-picker", GoogleFilePickerController);
 app.register("custom-autocomplete", CustomAutocompleteController);
 app.register("story-graph", StoryGraphController);
+app.register("decision-tree", DecisionTreeController);

--- a/assets/controllers/decision_tree_controller.js
+++ b/assets/controllers/decision_tree_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from '@hotwired/stimulus';
+import cytoscape from 'cytoscape';
+
+export default class extends Controller {
+    static targets = ['input'];
+    static values = {
+        elements: Array,
+    };
+
+    connect() {
+        this.cy = cytoscape({
+            container: this.element,
+            elements: this.elementsValue || [],
+            layout: {
+                name: 'breadthfirst',
+                nodeDimensionsIncludeLabels: true,
+            },
+            style: [
+                {
+                    selector: 'node',
+                    style: {
+                        'label': 'data(label)',
+                        'background-color': '#007bff',
+                        'color': '#fff',
+                        'text-valign': 'center',
+                        'text-halign': 'center',
+                        'font-size': '10px',
+                        'shape': 'roundrectangle'
+                    }
+                },
+                {
+                    selector: 'edge',
+                    style: {
+                        'width': 2,
+                        'line-color': '#ccc',
+                        'target-arrow-color': '#ccc',
+                        'target-arrow-shape': 'triangle',
+                        'curve-style': 'bezier'
+                    }
+                }
+            ]
+        });
+
+        this.updateInput();
+        this.cy.on('add remove', () => this.updateInput());
+    }
+
+    updateInput() {
+        if (this.hasInputTarget) {
+            this.inputTarget.value = JSON.stringify(this.cy.json().elements);
+        }
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -44,4 +44,7 @@ return [
         'version' => '2.4.3',
         'type' => 'css',
     ],
+    'decision-tree-controller' => [
+        'path' => './assets/controllers/decision_tree_controller.js',
+    ],
 ];


### PR DESCRIPTION
## Summary
- add a Stimulus controller to manage decision trees
- register the controller in `bootstrap.js`
- expose controller path in `importmap.php`

## Testing
- `composer ecs`
- `composer phpstan`

------
https://chatgpt.com/codex/tasks/task_e_684c789201708326a23b3a74ab70c36d