### PR TITLE
Add decision tree support for quests and threads

### DIFF
--- a/migrations/Version20250613192400.php
+++ b/migrations/Version20250613192400.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250613192400 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add decision_tree column to quest and thread tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest ADD decision_tree JSONB DEFAULT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread ADD decision_tree JSONB DEFAULT NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest DROP decision_tree
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread DROP decision_tree
+        SQL);
+    }
+}

--- a/src/Entity/StoryObject/Quest.php
+++ b/src/Entity/StoryObject/Quest.php
@@ -7,6 +7,7 @@ use App\Entity\Larp;
 use App\Repository\StoryObject\QuestRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use App\Entity\Enum\TargetType;
 
@@ -27,6 +28,9 @@ class Quest extends StoryObject
     /** @var Collection<LarpFaction> Specifically needed involved factions */
     #[ORM\ManyToMany(targetEntity: LarpFaction::class, mappedBy: 'quests')]
     private Collection $involvedFactions;
+
+    #[ORM\Column(type: Types::JSON, nullable: true, options: ['jsonb' => true])]
+    private ?array $decisionTree = null;
 
     public function __construct()
     {
@@ -95,6 +99,17 @@ class Quest extends StoryObject
     public function setInvolvedFactions(Collection $involvedFactions): void
     {
         $this->involvedFactions = $involvedFactions;
+    }
+
+    public function getDecisionTree(): ?array
+    {
+        return $this->decisionTree;
+    }
+
+    public function setDecisionTree(?array $decisionTree): self
+    {
+        $this->decisionTree = $decisionTree;
+        return $this;
     }
 
 

--- a/src/Entity/StoryObject/Thread.php
+++ b/src/Entity/StoryObject/Thread.php
@@ -7,6 +7,7 @@ use App\Entity\Larp;
 use App\Repository\StoryObject\ThreadRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use App\Entity\Enum\TargetType;
 
@@ -30,6 +31,9 @@ class Thread extends StoryObject
     /** @var Collection<LarpFaction> Specifically needed involved factions */
     #[ORM\ManyToMany(targetEntity: LarpFaction::class, mappedBy: 'threads')]
     private Collection $involvedFactions;
+
+    #[ORM\Column(type: Types::JSON, nullable: true, options: ['jsonb' => true])]
+    private ?array $decisionTree = null;
 
     public function __construct()
     {
@@ -111,6 +115,17 @@ class Thread extends StoryObject
     public function setEvents(Collection $events): void
     {
         $this->events = $events;
+    }
+
+    public function getDecisionTree(): ?array
+    {
+        return $this->decisionTree;
+    }
+
+    public function setDecisionTree(?array $decisionTree): self
+    {
+        $this->decisionTree = $decisionTree;
+        return $this;
     }
 
     public static function getTargetType(): TargetType


### PR DESCRIPTION
## Summary
- allow Quest and Thread story objects to keep a JSON decision tree
- add database migration for decision_tree columns

## Testing
- `composer ecs` *(fails: BracesPositionFixer, 147 errors fixable)*
- `composer phpstan` *(fails: class not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c79f43a748326875574e8c52b5f4b