### PR TITLE
Add decision tree editors for quests and threads

### DIFF
--- a/src/Controller/Backoffice/Story/QuestController.php
+++ b/src/Controller/Backoffice/Story/QuestController.php
@@ -72,6 +72,27 @@ class QuestController extends BaseController
         return $this->render('backoffice/larp/quest/modify.html.twig', [
             'form' => $form->createView(),
             'larp' => $larp,
+            'quest' => $quest,
+        ]);
+    }
+
+    #[Route('{quest}/tree', name: 'tree', methods: ['GET', 'POST'])]
+    public function tree(
+        Request         $request,
+        Larp            $larp,
+        Quest           $quest,
+        QuestRepository $questRepository,
+    ): Response {
+        if ($request->isMethod('POST')) {
+            $treeData = $request->request->get('decisionTree', '[]');
+            $quest->setDecisionTree(json_decode($treeData, true) ?? []);
+            $questRepository->save($quest);
+            $this->addFlash('success', $this->translator->trans('backoffice.common.success_save'));
+        }
+
+        return $this->render('backoffice/larp/quest/tree.html.twig', [
+            'larp' => $larp,
+            'quest' => $quest,
         ]);
     }
 

--- a/src/Controller/Backoffice/Story/ThreadController.php
+++ b/src/Controller/Backoffice/Story/ThreadController.php
@@ -86,6 +86,27 @@ class ThreadController extends BaseController
         return $this->render('backoffice/larp/thread/modify.html.twig', [
             'form' => $form->createView(),
             'larp' => $larp,
+            'thread' => $thread,
+        ]);
+    }
+
+    #[Route('{thread}/tree', name: 'tree', methods: ['GET', 'POST'])]
+    public function tree(
+        Request         $request,
+        Larp            $larp,
+        Thread          $thread,
+        ThreadRepository $threadRepository,
+    ): Response {
+        if ($request->isMethod('POST')) {
+            $treeData = $request->request->get('decisionTree', '[]');
+            $thread->setDecisionTree(json_decode($treeData, true) ?? []);
+            $threadRepository->save($thread);
+            $this->addFlash('success', $this->translator->trans('backoffice.common.success_save'));
+        }
+
+        return $this->render('backoffice/larp/thread/tree.html.twig', [
+            'larp' => $larp,
+            'thread' => $thread,
         ]);
     }
 

--- a/templates/backoffice/larp/quest/modify.html.twig
+++ b/templates/backoffice/larp/quest/modify.html.twig
@@ -6,6 +6,12 @@
         {{ form_widget(form) }}
         {{ form_end(form) }}
     </div>
+    {% if quest is defined %}
+        <a href="{{ path('backoffice_larp_story_quest_tree', { larp: larp.id, quest: quest.id }) }}"
+           class="btn btn-secondary mt-3">
+            Decision Tree
+        </a>
+    {% endif %}
 {% endblock %}
 
 {% block title %}{{ ''|trans }}{% endblock %}

--- a/templates/backoffice/larp/quest/tree.html.twig
+++ b/templates/backoffice/larp/quest/tree.html.twig
@@ -1,0 +1,12 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <form method="post">
+        <input type="hidden" name="_csrf_token" data-controller="csrf-protection">
+        <input type="hidden" name="decisionTree" data-decision-tree-target="input" />
+        <div data-controller="decision-tree"
+             data-decision-tree-elements-value='{{ quest.decisionTree|default([])|json_encode }}'
+             style="width: 100%; height: 600px;"></div>
+        <button type="submit" class="btn btn-primary mt-3">{{ 'common.save'|trans }}</button>
+    </form>
+{% endblock %}

--- a/templates/backoffice/larp/thread/modify.html.twig
+++ b/templates/backoffice/larp/thread/modify.html.twig
@@ -6,6 +6,12 @@
         {{ form_widget(form) }}
         {{ form_end(form) }}
     </div>
+    {% if thread is defined %}
+        <a href="{{ path('backoffice_larp_story_thread_tree', { larp: larp.id, thread: thread.id }) }}"
+           class="btn btn-secondary mt-3">
+            Decision Tree
+        </a>
+    {% endif %}
 {% endblock %}
 
 {% block title %}{{ ''|trans }}{% endblock %}

--- a/templates/backoffice/larp/thread/tree.html.twig
+++ b/templates/backoffice/larp/thread/tree.html.twig
@@ -1,0 +1,12 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <form method="post">
+        <input type="hidden" name="_csrf_token" data-controller="csrf-protection">
+        <input type="hidden" name="decisionTree" data-decision-tree-target="input" />
+        <div data-controller="decision-tree"
+             data-decision-tree-elements-value='{{ thread.decisionTree|default([])|json_encode }}'
+             style="width: 100%; height: 600px;"></div>
+        <button type="submit" class="btn btn-primary mt-3">{{ 'common.save'|trans }}</button>
+    </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow editing decision trees in quests and threads
- show decision tree editors using new templates
- link to tree editor pages from modification forms

## Testing
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon` *(fails: found 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c7b9688448326a174c825293ce7f0