### PR TITLE
Add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository Guidelines for Codex Agents
+
+## Code style
+- PHP code follows PSR-12. Indent with 4 spaces. Use typed properties, attributes, and `readonly` where suitable. Traits such as `UuidTraitEntity` and `CreatorAwareTrait` are used to share behavior between entities.
+- DTOs and command objects are lightweight `readonly` classes with public properties.
+- Doctrine ORM mappings use PHP attributes.
+- Enumerations define constants (e.g., `LarpStageStatus`).
+
+## Filtering forms
+- Filtering is implemented via Spiriit Form Filter Bundle. Filter types extend `AbstractType` and typically add fields using `Filters\*` classes. Options should set `'method' => 'GET'`, `'validation_groups' => ['filtering']`, disable CSRF and expect a `Larp` instance for `larp` option.
+
+## Frontend
+- JavaScript is written as ES6 modules and organized under `assets/controllers/` using Stimulus. Use 4 space indentation and define `targets`, `values`, and life‑cycle methods (e.g., `connect`). Webpack Encore bundles assets and the entry point is `assets/app.js`.
+
+## Tests and checks
+- Run unit tests with `vendor/bin/phpunit -c phpunit.xml.dist`.
+- Run code style checks with `vendor/bin/ecs check`.
+- Run static analysis with `vendor/bin/phpstan analyse -c phpstan.neon`.
+
+Make sure these checks pass before committing changes.


### PR DESCRIPTION
## Summary
- add AGENTS.md with coding, filtering, and testing guidelines

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/ecs check` *(fails: many style issues)*
- `vendor/bin/phpstan analyse -c phpstan.neon` *(fails: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684dbf4efa5083268d5cb5efd379dfc4