### PR TITLE
Add timestamps to Event entity

### DIFF
--- a/migrations/Version20250614184042.php
+++ b/migrations/Version20250614184042.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250614184042 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add start_time and end_time columns to event table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event ADD start_time TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event ADD end_time TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event DROP start_time
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event DROP end_time
+        SQL);
+    }
+}

--- a/src/Entity/StoryObject/Event.php
+++ b/src/Entity/StoryObject/Event.php
@@ -8,6 +8,7 @@ use App\Entity\LarpParticipant;
 use App\Repository\StoryObject\EventRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use App\Entity\Enum\TargetType;
 
@@ -40,6 +41,12 @@ class Event extends StoryObject
 
     #[ORM\Column(length: 20, nullable: true, enumType: StoryTimeUnit::class)]
     private ?StoryTimeUnit $storyTimeUnit = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $startTime = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $endTime = null;
 
     public function __construct()
     {
@@ -149,6 +156,26 @@ class Event extends StoryObject
     public function setStoryTimeUnit(?StoryTimeUnit $storyTimeUnit): void
     {
         $this->storyTimeUnit = $storyTimeUnit;
+    }
+
+    public function getStartTime(): ?\DateTimeInterface
+    {
+        return $this->startTime;
+    }
+
+    public function setStartTime(?\DateTimeInterface $startTime): void
+    {
+        $this->startTime = $startTime;
+    }
+
+    public function getEndTime(): ?\DateTimeInterface
+    {
+        return $this->endTime;
+    }
+
+    public function setEndTime(?\DateTimeInterface $endTime): void
+    {
+        $this->endTime = $endTime;
     }
 
 

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -10,6 +10,7 @@ use App\Repository\StoryObject\LarpCharacterRepository;
 use App\Repository\StoryObject\LarpFactionRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -31,6 +32,16 @@ class EventType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.event.description',
+            ])
+            ->add('startTime', DateTimeType::class, [
+                'label' => 'form.event.start_time',
+                'widget' => 'single_text',
+                'required' => false,
+            ])
+            ->add('endTime', DateTimeType::class, [
+                'label' => 'form.event.end_time',
+                'widget' => 'single_text',
+                'required' => false,
             ])
             ->add('involvedFactions', EntityType::class, [
                 'class' => LarpFaction::class,

--- a/src/Form/Filter/EventFilterType.php
+++ b/src/Form/Filter/EventFilterType.php
@@ -29,6 +29,12 @@ class EventFilterType extends AbstractType
             ->add('title', Filters\TextFilterType::class, [
                 'condition_pattern' => FilterOperands::STRING_CONTAINS,
             ])
+            ->add('startTime', Filters\DateTimeFilterType::class, [
+                'widget' => 'single_text',
+            ])
+            ->add('endTime', Filters\DateTimeFilterType::class, [
+                'widget' => 'single_text',
+            ])
             ->add('thread', EntityType::class, [
                 'class' => Thread::class,
                 'choice_label' => 'title',

--- a/templates/backoffice/larp/event/list.html.twig
+++ b/templates/backoffice/larp/event/list.html.twig
@@ -45,6 +45,14 @@
                         field: 'title',
                         label: 'common.name'|trans
                     } %}
+                    {% include 'includes/sort_th.html.twig' with {
+                        field: 'startTime',
+                        label: 'form.event.start_time'|trans({}, 'forms')
+                    } %}
+                    {% include 'includes/sort_th.html.twig' with {
+                        field: 'endTime',
+                        label: 'form.event.end_time'|trans({}, 'forms')
+                    } %}
                     <th>{{ 'common.description'|trans }}</th>
                     <th>{{ 'common.actions'|trans }}</th>
                 </tr>
@@ -53,6 +61,8 @@
                 {% for event in events %}
                     <tr>
                         <td>{{ event.title }}</td>
+                        <td>{{ event.startTime ? event.startTime|date('Y-m-d H:i') : '-' }}</td>
+                        <td>{{ event.endTime ? event.endTime|date('Y-m-d H:i') : '-' }}</td>
                         <td>{{ event.description|default('-') }}</td>
                         <td>
                             <a href="{{ path('backoffice_larp_story_event_modify', { larp: larp.id, event: event.id }) }}"

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -65,3 +65,10 @@ form:
     is_purchased: "Purchased"
     quantity: "Quantity"
     cost: "Cost"
+  event:
+    name: 'Event Name'
+    description: 'Event Description'
+    start_time: 'Start Time'
+    end_time: 'End Time'
+    factions: 'Factions involved in event'
+    choose_faction: 'Choose a faction...'


### PR DESCRIPTION
## Summary
- add `startTime` and `endTime` fields to `Event`
- support new datetime fields in EventType form
- allow filtering by `startTime` and `endTime`
- display timestamps in event list view
- provide migration and translations for new fields

## Testing
- `vendor/bin/ecs check src/Entity/StoryObject/Event.php src/Form/EventType.php src/Form/Filter/EventFilterType.php templates/backoffice/larp/event/list.html.twig translations/forms.en.yaml migrations/Version20250614184042.php`
- `vendor/bin/phpstan analyse src/Entity/StoryObject/Event.php src/Form/EventType.php src/Form/Filter/EventFilterType.php --no-progress`
- `composer phpstan` *(fails: class not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc1640f64832687767a5b1886a75c