### PR TITLE
Implement Larp incident reporting basics

### DIFF
--- a/src/Controller/Backoffice/LarpIncidentController.php
+++ b/src/Controller/Backoffice/LarpIncidentController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Controller\Backoffice;
+
+use App\Entity\Larp;
+use App\Entity\LarpIncident;
+use App\Repository\LarpIncidentRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/larp/{larp}/incident', name: 'backoffice_larp_incident_')]
+class LarpIncidentController extends AbstractController
+{
+    #[Route('/list', name: 'list', methods: ['GET'])]
+    public function list(Larp $larp, LarpIncidentRepository $repository): Response
+    {
+        $incidents = $repository->findBy(['larp' => $larp]);
+
+        return $this->render('backoffice/larp/incidents.html.twig', [
+            'larp' => $larp,
+            'incidents' => $incidents,
+        ]);
+    }
+
+    #[Route('/{incident}', name: 'view', methods: ['GET'])]
+    public function view(Larp $larp, LarpIncident $incident): Response
+    {
+        return $this->render('backoffice/larp/incident/view.html.twig', [
+            'larp' => $larp,
+            'incident' => $incident,
+        ]);
+    }
+}

--- a/src/Entity/Enum/LarpIncidentStatus.php
+++ b/src/Entity/Enum/LarpIncidentStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum LarpIncidentStatus: string
+{
+    case NEW = 'NEW';
+    case IN_PROGRESS = 'IN_PROGRESS';
+    case FEEDBACK_GIVEN = 'FEEDBACK_GIVEN';
+    case CLOSED = 'CLOSED';
+}

--- a/src/Entity/LarpIncident.php
+++ b/src/Entity/LarpIncident.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Enum\LarpIncidentStatus;
+use App\Entity\Trait\CreatorAwareInterface;
+use App\Entity\Trait\CreatorAwareTrait;
+use App\Entity\Trait\LarpAwareInterface;
+use App\Entity\Trait\UuidTraitEntity;
+use App\Repository\LarpIncidentRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: LarpIncidentRepository::class)]
+class LarpIncident implements LarpAwareInterface, CreatorAwareInterface
+{
+    use UuidTraitEntity;
+    use CreatorAwareTrait;
+
+    #[ORM\ManyToOne(targetEntity: Larp::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Larp $larp = null;
+
+    #[ORM\Column(length: 64)]
+    private ?string $reportCode = null;
+
+    #[ORM\Column(length: 64, unique: true)]
+    private ?string $caseId = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(type: Types::TEXT)]
+    private ?string $description = null;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $allowFeedback = false;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $contactAccused = false;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $allowMediator = false;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $stayAnonymous = false;
+
+    #[ORM\Column(enumType: LarpIncidentStatus::class)]
+    private LarpIncidentStatus $status = LarpIncidentStatus::NEW;
+
+    #[ORM\Column(type: Types::BOOLEAN, nullable: true)]
+    private ?bool $needsPoliceSupport = null;
+
+    public function getLarp(): ?Larp
+    {
+        return $this->larp;
+    }
+
+    public function setLarp(Larp $larp): self
+    {
+        $this->larp = $larp;
+        return $this;
+    }
+
+    public function getReportCode(): ?string
+    {
+        return $this->reportCode;
+    }
+
+    public function setReportCode(string $reportCode): self
+    {
+        $this->reportCode = $reportCode;
+        return $this;
+    }
+
+    public function getCaseId(): ?string
+    {
+        return $this->caseId;
+    }
+
+    public function setCaseId(string $caseId): self
+    {
+        $this->caseId = $caseId;
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function isAllowFeedback(): bool
+    {
+        return $this->allowFeedback;
+    }
+
+    public function setAllowFeedback(bool $allowFeedback): self
+    {
+        $this->allowFeedback = $allowFeedback;
+        return $this;
+    }
+
+    public function isContactAccused(): bool
+    {
+        return $this->contactAccused;
+    }
+
+    public function setContactAccused(bool $contactAccused): self
+    {
+        $this->contactAccused = $contactAccused;
+        return $this;
+    }
+
+    public function isAllowMediator(): bool
+    {
+        return $this->allowMediator;
+    }
+
+    public function setAllowMediator(bool $allowMediator): self
+    {
+        $this->allowMediator = $allowMediator;
+        return $this;
+    }
+
+    public function isStayAnonymous(): bool
+    {
+        return $this->stayAnonymous;
+    }
+
+    public function setStayAnonymous(bool $stayAnonymous): self
+    {
+        $this->stayAnonymous = $stayAnonymous;
+        return $this;
+    }
+
+    public function getStatus(): LarpIncidentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(LarpIncidentStatus $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getNeedsPoliceSupport(): ?bool
+    {
+        return $this->needsPoliceSupport;
+    }
+
+    public function setNeedsPoliceSupport(?bool $needsPoliceSupport): self
+    {
+        $this->needsPoliceSupport = $needsPoliceSupport;
+        return $this;
+    }
+}

--- a/src/Form/LarpIncidentType.php
+++ b/src/Form/LarpIncidentType.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\LarpIncident;
+use App\Service\Larp\ParticipantCodeValidator;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LarpIncidentType extends AbstractType
+{
+    public function __construct(private readonly ParticipantCodeValidator $validator)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('reportCode', TextType::class, [
+                'label' => 'form.incident.report_code',
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'form.incident.description',
+            ])
+            ->add('allowFeedback', CheckboxType::class, [
+                'label' => 'form.incident.allow_feedback',
+                'required' => false,
+            ])
+            ->add('contactAccused', CheckboxType::class, [
+                'label' => 'form.incident.contact_accused',
+                'required' => false,
+            ])
+            ->add('allowMediator', CheckboxType::class, [
+                'label' => 'form.incident.allow_mediator',
+                'required' => false,
+            ])
+            ->add('stayAnonymous', CheckboxType::class, [
+                'label' => 'form.incident.stay_anonymous',
+                'required' => false,
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.submit',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => LarpIncident::class,
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Repository/LarpIncidentRepository.php
+++ b/src/Repository/LarpIncidentRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LarpIncident;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends BaseRepository<LarpIncident>
+ */
+class LarpIncidentRepository extends BaseRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LarpIncident::class);
+    }
+}

--- a/src/Service/Larp/ParticipantCodeGenerator.php
+++ b/src/Service/Larp/ParticipantCodeGenerator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Service\Larp;
+
+use App\Entity\Larp;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class ParticipantCodeGenerator
+{
+    public function generate(Larp $larp): string
+    {
+        $prefix = substr($larp->getId()->toRfc4122(), 0, 8);
+        $random = bin2hex(random_bytes(3));
+        $checksum = substr(hash('crc32b', $prefix . $random), 0, 4);
+        return sprintf('%s-%s-%s', $prefix, $random, $checksum);
+    }
+}

--- a/src/Service/Larp/ParticipantCodeValidator.php
+++ b/src/Service/Larp/ParticipantCodeValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Service\Larp;
+
+use App\Entity\Larp;
+
+final readonly class ParticipantCodeValidator
+{
+    public function validate(string $code, Larp $larp): bool
+    {
+        $parts = explode('-', $code);
+        if (count($parts) !== 3) {
+            return false;
+        }
+        [$prefix, $random, $checksum] = $parts;
+        if ($prefix !== substr($larp->getId()->toRfc4122(), 0, 8)) {
+            return false;
+        }
+        $expected = substr(hash('crc32b', $prefix . $random), 0, 4);
+        return hash_equals($expected, $checksum);
+    }
+}

--- a/src/Twig/Components/IncidentFormComponent.php
+++ b/src/Twig/Components/IncidentFormComponent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Twig\Components;
+
+use App\Entity\Larp;
+use App\Entity\LarpIncident;
+use App\Form\LarpIncidentType;
+use App\Repository\LarpIncidentRepository;
+use App\Service\Larp\ParticipantCodeValidator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Uid\Uuid;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\ComponentWithFormTrait;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('incident_form')]
+class IncidentFormComponent extends AbstractController
+{
+    use DefaultActionTrait;
+    use ComponentWithFormTrait;
+
+    public Larp $larp;
+
+    public function __construct(
+        private readonly LarpIncidentRepository $repository,
+        private readonly ParticipantCodeValidator $validator,
+    ) {
+    }
+
+    protected function instantiateForm(): FormInterface
+    {
+        $incident = new LarpIncident();
+        $incident->setLarp($this->larp);
+        $incident->setCreatedAt(new \DateTimeImmutable());
+
+        return $this->createForm(LarpIncidentType::class, $incident);
+    }
+
+    #[LiveAction]
+    public function submit(): void
+    {
+        $this->submitForm();
+        /** @var LarpIncident $incident */
+        $incident = $this->getForm()->getData();
+        if (!$this->validator->validate($incident->getReportCode(), $incident->getLarp())) {
+            $this->getForm()->get('reportCode')->addError(new \Symfony\Component\Form\FormError('Invalid code'));
+            return;
+        }
+        $incident->setCaseId(Uuid::v4()->toRfc4122());
+        $this->repository->save($incident);
+    }
+}

--- a/templates/backoffice/larp/incident/view.html.twig
+++ b/templates/backoffice/larp/incident/view.html.twig
@@ -1,0 +1,8 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block title %}{{ 'common.incident'|trans }}{% endblock %}
+
+{% block larp_content %}
+    <h1>{{ incident.caseId }}</h1>
+    <p>{{ incident.description }}</p>
+{% endblock %}

--- a/templates/backoffice/larp/incidents.html.twig
+++ b/templates/backoffice/larp/incidents.html.twig
@@ -4,4 +4,15 @@
 
 {% block larp_content %}
     <h1>{{ 'common.incidents'|trans }}</h1>
+    <ul>
+        {% for incident in incidents %}
+            <li>
+                <a href="{{ path('backoffice_larp_incident_view', {larp: larp.id, incident: incident.id}) }}">
+                    {{ incident.caseId }} - {{ incident.status.value }}
+                </a>
+            </li>
+        {% else %}
+            <li>{{ 'common.empty_list'|trans }}</li>
+        {% endfor %}
+    </ul>
 {% endblock %}

--- a/tests/Service/ParticipantCodeValidatorTest.php
+++ b/tests/Service/ParticipantCodeValidatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Larp;
+use App\Service\Larp\ParticipantCodeGenerator;
+use App\Service\Larp\ParticipantCodeValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class ParticipantCodeValidatorTest extends TestCase
+{
+    public function testValidCode(): void
+    {
+        $larp = new Larp();
+        $generator = new ParticipantCodeGenerator();
+        $validator = new ParticipantCodeValidator();
+        $code = $generator->generate($larp);
+        $this->assertTrue($validator->validate($code, $larp));
+    }
+
+    public function testInvalidCode(): void
+    {
+        $larp = new Larp();
+        $other = new Larp();
+        $generator = new ParticipantCodeGenerator();
+        $validator = new ParticipantCodeValidator();
+        $code = $generator->generate($larp);
+        $this->assertFalse($validator->validate($code, $other));
+    }
+}

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -82,3 +82,10 @@ form:
   priority: 'Priority'
   justification: 'Justification'
   visual: 'Visual ideas'
+  incident:
+    report_code: "Participant code"
+    description: "Describe what happened"
+    allow_feedback: "I want feedback"
+    contact_accused: "Allow contacting accused"
+    allow_mediator: "Allow mediator"
+    stay_anonymous: "Stay anonymous"

--- a/translations/forms.pl.yaml
+++ b/translations/forms.pl.yaml
@@ -1,0 +1,7 @@
+  incident:
+    report_code: "Kod uczestnika"
+    description: "Opisz zdarzenie"
+    allow_feedback: "Chcę informację zwrotną"
+    contact_accused: "Pozwól na kontakt z oskarżonym"
+    allow_mediator: "Zgadzam się na mediatora"
+    stay_anonymous: "Pozostań anonimowy"


### PR DESCRIPTION
## Summary
- add `LarpIncident` entity with enums and repository
- add participant code generator/validator services
- create form and live component for incidents
- create basic backoffice controller and templates
- translate incident form fields
- test participant code validator

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist --stop-on-failure`
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`

------
https://chatgpt.com/codex/tasks/task_e_684f110b04e48326860cb46040fa03e7