### PR TITLE
Add recruitment entities and related features

### DIFF
--- a/migrations/Version20250615120000.php
+++ b/migrations/Version20250615120000.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250615120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add story recruitment and proposal tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE story_recruitment (id UUID NOT NULL, story_object_id UUID NOT NULL, required_number INT NOT NULL, type VARCHAR(255) NOT NULL, notes TEXT DEFAULT NULL, created_by_id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_EF6E7DBF6CDE5A ON story_recruitment (story_object_id)');
+        $this->addSql('COMMENT ON COLUMN story_recruitment.id IS \"(DC2Type:uuid)\"');
+        $this->addSql('COMMENT ON COLUMN story_recruitment.story_object_id IS \"(DC2Type:uuid)\"');
+        $this->addSql('COMMENT ON COLUMN story_recruitment.created_by_id IS \"(DC2Type:uuid)\"');
+
+        $this->addSql('CREATE TABLE recruitment_proposal (id UUID NOT NULL, recruitment_id UUID NOT NULL, character_id UUID NOT NULL, status VARCHAR(255) NOT NULL, comment TEXT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_8DCE6F4BA0D0F5AA ON recruitment_proposal (recruitment_id)');
+        $this->addSql('CREATE INDEX IDX_8DCE6F4B1138C7E1 ON recruitment_proposal (character_id)');
+        $this->addSql('COMMENT ON COLUMN recruitment_proposal.id IS \"(DC2Type:uuid)\"');
+        $this->addSql('COMMENT ON COLUMN recruitment_proposal.recruitment_id IS \"(DC2Type:uuid)\"');
+        $this->addSql('COMMENT ON COLUMN recruitment_proposal.character_id IS \"(DC2Type:uuid)\"');
+
+        $this->addSql('ALTER TABLE story_recruitment ADD CONSTRAINT FK_EF6E7DBF6CDE5A FOREIGN KEY (story_object_id) REFERENCES story_object (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE story_recruitment ADD CONSTRAINT FK_EF6E7DBB03A8386 FOREIGN KEY (created_by_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE recruitment_proposal ADD CONSTRAINT FK_8DCE6F4BA0D0F5AA FOREIGN KEY (recruitment_id) REFERENCES story_recruitment (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE recruitment_proposal ADD CONSTRAINT FK_8DCE6F4B1138C7E1 FOREIGN KEY (character_id) REFERENCES larp_character (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruitment_proposal DROP CONSTRAINT FK_8DCE6F4BA0D0F5AA');
+        $this->addSql('ALTER TABLE recruitment_proposal DROP CONSTRAINT FK_8DCE6F4B1138C7E1');
+        $this->addSql('ALTER TABLE story_recruitment DROP CONSTRAINT FK_EF6E7DBF6CDE5A');
+        $this->addSql('ALTER TABLE story_recruitment DROP CONSTRAINT FK_EF6E7DBB03A8386');
+        $this->addSql('DROP TABLE recruitment_proposal');
+        $this->addSql('DROP TABLE story_recruitment');
+    }
+}

--- a/src/Controller/Backoffice/Story/QuestController.php
+++ b/src/Controller/Backoffice/Story/QuestController.php
@@ -3,13 +3,19 @@
 namespace App\Controller\Backoffice\Story;
 
 use App\Controller\BaseController;
+use App\Entity\Enum\RecruitmentProposalStatus;
 use App\Entity\Larp;
 use App\Entity\StoryObject\Quest;
+use App\Entity\StoryObject\RecruitmentProposal;
 use App\Entity\StoryObject\StoryObject;
+use App\Entity\StoryObject\StoryRecruitment;
 use App\Form\Filter\QuestFilterType;
 use App\Form\QuestType;
+use App\Form\StoryRecruitmentType;
 use App\Helper\Logger;
 use App\Repository\StoryObject\QuestRepository;
+use App\Repository\StoryObject\RecruitmentProposalRepository;
+use App\Repository\StoryObject\StoryRecruitmentRepository;
 use App\Service\Integrations\IntegrationManager;
 use App\Service\Larp\LarpManager;
 use Symfony\Component\HttpFoundation\Request;
@@ -134,5 +140,59 @@ class QuestController extends BaseController
     public function importFile(Larp $larp, LarpManager $larpManager): Response
     {
         return new Response('TODO:: Import from file csv/xlsx');
+    }
+
+    #[Route('{quest}/recruitment', name: 'recruitment', defaults: ['recruitment' => null], methods: ['GET', 'POST'])]
+    public function recruitment(
+        Request                    $request,
+        Larp                       $larp,
+        Quest                      $quest,
+        StoryRecruitmentRepository $recruitmentRepository,
+        ?StoryRecruitment          $recruitment = null,
+    ): Response {
+        if (!$recruitment) {
+            $recruitment = new StoryRecruitment();
+            $recruitment->setStoryObject($quest);
+            $recruitment->setCreatedBy($this->getUser());
+        }
+
+        $form = $this->createForm(StoryRecruitmentType::class, $recruitment);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $recruitmentRepository->save($recruitment);
+            $this->addFlash('success', $this->translator->trans('backoffice.common.success_save'));
+
+            return $this->redirectToRoute('backoffice_larp_story_quest_list', [
+                'larp' => $larp->getId(),
+            ]);
+        }
+
+        return $this->render('backoffice/larp/recruitment/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
+        ]);
+    }
+
+    #[Route('proposal/{proposal}/accept', name: 'proposal_accept', methods: ['POST'])]
+    public function acceptProposal(RecruitmentProposal $proposal, RecruitmentProposalRepository $proposalRepository): Response
+    {
+        $proposal->setStatus(RecruitmentProposalStatus::ACCEPTED);
+        $proposalRepository->save($proposal);
+
+        return $this->redirectToRoute('backoffice_larp_story_quest_list', [
+            'larp' => $proposal->getRecruitment()->getStoryObject()->getLarp()->getId(),
+        ]);
+    }
+
+    #[Route('proposal/{proposal}/reject', name: 'proposal_reject', methods: ['POST'])]
+    public function rejectProposal(RecruitmentProposal $proposal, RecruitmentProposalRepository $proposalRepository): Response
+    {
+        $proposal->setStatus(RecruitmentProposalStatus::REJECTED);
+        $proposalRepository->save($proposal);
+
+        return $this->redirectToRoute('backoffice_larp_story_quest_list', [
+            'larp' => $proposal->getRecruitment()->getStoryObject()->getLarp()->getId(),
+        ]);
     }
 }

--- a/src/Entity/Enum/RecruitmentProposalStatus.php
+++ b/src/Entity/Enum/RecruitmentProposalStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum RecruitmentProposalStatus: string
+{
+    case PENDING = 'pending';
+    case ACCEPTED = 'accepted';
+    case REJECTED = 'rejected';
+}

--- a/src/Entity/StoryObject/RecruitmentProposal.php
+++ b/src/Entity/StoryObject/RecruitmentProposal.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Entity\StoryObject;
+
+use App\Entity\Enum\RecruitmentProposalStatus;
+use App\Entity\Trait\UuidTraitEntity;
+use App\Repository\StoryObject\RecruitmentProposalRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+
+#[ORM\Entity(repositoryClass: RecruitmentProposalRepository::class)]
+class RecruitmentProposal
+{
+    use UuidTraitEntity;
+    use TimestampableEntity;
+
+    #[ORM\ManyToOne(targetEntity: StoryRecruitment::class, inversedBy: 'proposals')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?StoryRecruitment $recruitment = null;
+
+    #[ORM\ManyToOne(targetEntity: LarpCharacter::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?LarpCharacter $character = null;
+
+    #[ORM\Column(enumType: RecruitmentProposalStatus::class)]
+    private RecruitmentProposalStatus $status = RecruitmentProposalStatus::PENDING;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $comment = null;
+
+    public function getRecruitment(): ?StoryRecruitment
+    {
+        return $this->recruitment;
+    }
+
+    public function setRecruitment(?StoryRecruitment $recruitment): void
+    {
+        $this->recruitment = $recruitment;
+    }
+
+    public function getCharacter(): ?LarpCharacter
+    {
+        return $this->character;
+    }
+
+    public function setCharacter(LarpCharacter $character): void
+    {
+        $this->character = $character;
+    }
+
+    public function getStatus(): RecruitmentProposalStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(RecruitmentProposalStatus $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?string $comment): void
+    {
+        $this->comment = $comment;
+    }
+}

--- a/src/Entity/StoryObject/StoryRecruitment.php
+++ b/src/Entity/StoryObject/StoryRecruitment.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Entity\StoryObject;
+
+use App\Entity\Trait\CreatorAwareTrait;
+use App\Entity\Trait\UuidTraitEntity;
+use App\Repository\StoryObject\StoryRecruitmentRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+
+#[ORM\Entity(repositoryClass: StoryRecruitmentRepository::class)]
+class StoryRecruitment
+{
+    use UuidTraitEntity;
+    use TimestampableEntity;
+    use CreatorAwareTrait;
+
+    #[ORM\ManyToOne(targetEntity: StoryObject::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?StoryObject $storyObject = null;
+
+    #[ORM\Column(type: 'integer')]
+    private int $requiredNumber = 1;
+
+    #[ORM\Column(length: 255)]
+    private string $type;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $notes = null;
+
+    /** @var Collection<RecruitmentProposal> */
+    #[ORM\OneToMany(mappedBy: 'recruitment', targetEntity: RecruitmentProposal::class, cascade: ['persist', 'remove'])]
+    private Collection $proposals;
+
+    public function __construct()
+    {
+        $this->proposals = new ArrayCollection();
+    }
+
+    public function getStoryObject(): ?StoryObject
+    {
+        return $this->storyObject;
+    }
+
+    public function setStoryObject(StoryObject $storyObject): void
+    {
+        $this->storyObject = $storyObject;
+    }
+
+    public function getRequiredNumber(): int
+    {
+        return $this->requiredNumber;
+    }
+
+    public function setRequiredNumber(int $requiredNumber): void
+    {
+        $this->requiredNumber = $requiredNumber;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): void
+    {
+        $this->notes = $notes;
+    }
+
+    public function getProposals(): Collection
+    {
+        return $this->proposals;
+    }
+
+    public function addProposal(RecruitmentProposal $proposal): void
+    {
+        if (!$this->proposals->contains($proposal)) {
+            $this->proposals->add($proposal);
+            $proposal->setRecruitment($this);
+        }
+    }
+
+    public function removeProposal(RecruitmentProposal $proposal): void
+    {
+        if ($this->proposals->removeElement($proposal)) {
+            if ($proposal->getRecruitment() === $this) {
+                $proposal->setRecruitment(null);
+            }
+        }
+    }
+}

--- a/src/Form/RecruitmentProposalType.php
+++ b/src/Form/RecruitmentProposalType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Larp;
+use App\Entity\StoryObject\LarpCharacter;
+use App\Entity\StoryObject\RecruitmentProposal;
+use App\Repository\StoryObject\LarpCharacterRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RecruitmentProposalType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Larp $larp */
+        $larp = $options['larp'];
+
+        $builder
+            ->add('character', EntityType::class, [
+                'class' => LarpCharacter::class,
+                'choice_label' => 'title',
+                'label' => 'form.proposal.character',
+                'query_builder' => function (LarpCharacterRepository $repo) use ($larp) {
+                    return $repo->createQueryBuilder('c')
+                        ->where('c.larp = :larp')
+                        ->setParameter('larp', $larp);
+                },
+                'autocomplete' => true,
+            ])
+            ->add('comment', TextareaType::class, [
+                'required' => false,
+                'label' => 'form.proposal.comment',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.submit',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => RecruitmentProposal::class,
+            'translation_domain' => 'forms',
+            'larp' => null,
+        ]);
+
+        $resolver->setRequired('larp');
+        $resolver->setAllowedTypes('larp', Larp::class);
+    }
+}

--- a/src/Form/StoryRecruitmentType.php
+++ b/src/Form/StoryRecruitmentType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\StoryObject\StoryRecruitment;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class StoryRecruitmentType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('requiredNumber', IntegerType::class, [
+                'label' => 'form.recruitment.number',
+            ])
+            ->add('type', TextType::class, [
+                'label' => 'form.recruitment.type',
+            ])
+            ->add('notes', TextareaType::class, [
+                'required' => false,
+                'label' => 'form.recruitment.notes',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.submit',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => StoryRecruitment::class,
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Repository/StoryObject/RecruitmentProposalRepository.php
+++ b/src/Repository/StoryObject/RecruitmentProposalRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository\StoryObject;
+
+use App\Entity\StoryObject\RecruitmentProposal;
+use App\Repository\BaseRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends BaseRepository<RecruitmentProposal>
+ */
+class RecruitmentProposalRepository extends BaseRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RecruitmentProposal::class);
+    }
+}

--- a/src/Repository/StoryObject/StoryRecruitmentRepository.php
+++ b/src/Repository/StoryObject/StoryRecruitmentRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository\StoryObject;
+
+use App\Entity\StoryObject\StoryRecruitment;
+use App\Repository\BaseRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends BaseRepository<StoryRecruitment>
+ */
+class StoryRecruitmentRepository extends BaseRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, StoryRecruitment::class);
+    }
+}

--- a/templates/backoffice/larp/proposal/list.html.twig
+++ b/templates/backoffice/larp/proposal/list.html.twig
@@ -1,0 +1,19 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <h2>{{ 'backoffice.proposal.list'|trans }}</h2>
+    <ul>
+        {% for proposal in proposals %}
+            <li>{{ proposal.character.title }} - {{ proposal.status.value }}
+                <form method="post" action="{{ path(accept_route, {larp: larp.id, id: proposal.id}) }}" style="display:inline">
+                    <button class="btn btn-sm btn-success" type="submit">{{ 'backoffice.proposal.accept'|trans }}</button>
+                </form>
+                <form method="post" action="{{ path(reject_route, {larp: larp.id, id: proposal.id}) }}" style="display:inline">
+                    <button class="btn btn-sm btn-danger" type="submit">{{ 'backoffice.proposal.reject'|trans }}</button>
+                </form>
+            </li>
+        {% else %}
+            <li>{{ 'backoffice.proposal.none'|trans }}</li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/templates/backoffice/larp/recruitment/list.html.twig
+++ b/templates/backoffice/larp/recruitment/list.html.twig
@@ -1,0 +1,15 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <h2>{{ 'backoffice.recruitment.open'|trans }}</h2>
+    <ul>
+        {% for recruitment in recruitments %}
+            <li>
+                {{ recruitment.type }} ({{ recruitment.requiredNumber }})
+                <a href="{{ path(modify_route, {larp: larp.id, id: recruitment.id}) }}" class="btn btn-sm btn-secondary">{{ 'common.edit'|trans }}</a>
+            </li>
+        {% else %}
+            <li>{{ 'backoffice.recruitment.none'|trans }}</li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/templates/backoffice/larp/recruitment/modify.html.twig
+++ b/templates/backoffice/larp/recruitment/modify.html.twig
@@ -1,0 +1,7 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    {{ form_start(form) }}
+    {{ form_widget(form) }}
+    {{ form_end(form) }}
+{% endblock %}

--- a/tests/Controller/RecruitmentControllerTest.php
+++ b/tests/Controller/RecruitmentControllerTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class RecruitmentControllerTest extends WebTestCase
+{
+    public function testRecruitmentRouteRequiresAuthentication(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/backoffice/larp/00000000-0000-0000-0000-000000000000/story/thread/123/recruitment');
+        $this->assertTrue($client->getResponse()->isRedirection() || $client->getResponse()->isClientError());
+    }
+}

--- a/tests/Repository/RecruitmentProposalRepositoryTest.php
+++ b/tests/Repository/RecruitmentProposalRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\StoryObject\RecruitmentProposal;
+use App\Repository\StoryObject\RecruitmentProposalRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+class RecruitmentProposalRepositoryTest extends TestCase
+{
+    public function testSave(): void
+    {
+        $entity = new RecruitmentProposal();
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist')->with($entity);
+        $em->expects($this->once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $repository = new class($registry, $em) extends RecruitmentProposalRepository {
+            public function __construct(ManagerRegistry $registry, private EntityManagerInterface $em)
+            {
+                parent::__construct($registry);
+            }
+            protected function getEntityManager(): EntityManagerInterface
+            {
+                return $this->em;
+            }
+        };
+
+        $repository->save($entity);
+    }
+}

--- a/tests/Repository/StoryRecruitmentRepositoryTest.php
+++ b/tests/Repository/StoryRecruitmentRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\StoryObject\StoryRecruitment;
+use App\Repository\StoryObject\StoryRecruitmentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+class StoryRecruitmentRepositoryTest extends TestCase
+{
+    public function testSave(): void
+    {
+        $entity = new StoryRecruitment();
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist')->with($entity);
+        $em->expects($this->once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $repository = new class($registry, $em) extends StoryRecruitmentRepository {
+            public function __construct(ManagerRegistry $registry, private EntityManagerInterface $em)
+            {
+                parent::__construct($registry);
+            }
+            protected function getEntityManager(): EntityManagerInterface
+            {
+                return $this->em;
+            }
+        };
+
+        $repository->save($entity);
+    }
+}

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -15,6 +15,13 @@ form:
     valid_to: "Invitation code valid to"
     role: "Role"
     character: "Choose a character..."
+  recruitment:
+    number: "Required number"
+    type: "Type"
+    notes: "Notes"
+  proposal:
+    character: "Character"
+    comment: "Comment"
   mapping:
     spreadsheet:
       sheet_name: "Spreadsheet Name"

--- a/translations/forms.pl.yaml
+++ b/translations/forms.pl.yaml
@@ -6,3 +6,10 @@ form:
     contact_accused: "Pozwól na kontakt z oskarżonym"
     allow_mediator: "Zgadzam się na mediatora"
     stay_anonymous: "Pozostań anonimowy"
+  recruitment:
+    number: "Liczba potrzebnych"
+    type: "Typ"
+    notes: "Notatki"
+  proposal:
+    character: "Postać"
+    comment: "Komentarz"

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -135,3 +135,12 @@ file_select:
 login_page:
   info: Wenn du bereits registriert bist, melde dich an und verbinde Konten in deinen Kontoeinstellungen.
   title: Registrierung / Anmeldung
+backoffice:
+  recruitment:
+    open: "Offene Rekrutierungen"
+    none: "Keine Rekrutierungen"
+  proposal:
+    list: "Vorschläge"
+    accept: "Annehmen"
+    reject: "Ablehnen"
+    none: "Keine Vorschläge"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -181,3 +181,12 @@ relation_type:
   enemy: "Enemy"
   family: "Family"
   ally: "Ally"
+backoffice:
+  recruitment:
+    open: "Open recruitments"
+    none: "No recruitments"
+  proposal:
+    list: "Proposals"
+    accept: "Accept"
+    reject: "Reject"
+    none: "No proposals"

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -135,3 +135,12 @@ file_select:
 login_page:
   info: Jeśli już masz konto, zaloguj się i połącz konta w ustawieniach konta.
   title: Rejestracja / Logowanie
+backoffice:
+  recruitment:
+    open: "Otwarte rekrutacje"
+    none: "Brak rekrutacji"
+  proposal:
+    list: "Propozycje"
+    accept: "Akceptuj"
+    reject: "Odrzuć"
+    none: "Brak propozycji"


### PR DESCRIPTION
## Summary
- add StoryRecruitment and RecruitmentProposal entities
- add repositories and Doctrine migration
- implement forms and controller actions for recruitments
- add Twig templates and translations
- add unit tests for repositories and controller route

## Testing
- `composer ecs`
- `composer phpstan`
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_684f23f0d8848326b88a0aecc11b31dc