### PR TITLE
Add story recruitment listing features

### DIFF
--- a/src/Controller/Backoffice/Story/EventsController.php
+++ b/src/Controller/Backoffice/Story/EventsController.php
@@ -122,6 +122,35 @@ class EventsController extends BaseController
         return new Response('TODO:: Import from file csv/xlsx');
     }
 
+    #[Route('recruitments', name: 'recruitment_list', methods: ['GET'])]
+    public function recruitmentList(Larp $larp, StoryRecruitmentRepository $recruitmentRepository): Response
+    {
+        $recruitments = $recruitmentRepository->createQueryBuilder('r')
+            ->join('r.storyObject', 'o')
+            ->andWhere('o INSTANCE OF ' . Event::class)
+            ->andWhere('o.larp = :larp')
+            ->setParameter('larp', $larp)
+            ->getQuery()
+            ->getResult();
+
+        return $this->render('backoffice/larp/recruitment/list.html.twig', [
+            'recruitments' => $recruitments,
+            'larp' => $larp,
+            'modify_route' => 'backoffice_larp_story_event_recruitment',
+        ]);
+    }
+
+    #[Route('recruitment/{recruitment}/proposals', name: 'proposal_list', methods: ['GET'])]
+    public function proposalList(StoryRecruitment $recruitment): Response
+    {
+        return $this->render('backoffice/larp/proposal/list.html.twig', [
+            'proposals' => $recruitment->getProposals(),
+            'larp' => $recruitment->getStoryObject()->getLarp(),
+            'accept_route' => 'backoffice_larp_story_event_proposal_accept',
+            'reject_route' => 'backoffice_larp_story_event_proposal_reject',
+        ]);
+    }
+
     #[Route('{event}/recruitment', name: 'recruitment', defaults: ['recruitment' => null], methods: ['GET', 'POST'])]
     public function recruitment(
         Request                    $request,

--- a/src/Controller/Backoffice/Story/QuestController.php
+++ b/src/Controller/Backoffice/Story/QuestController.php
@@ -142,6 +142,35 @@ class QuestController extends BaseController
         return new Response('TODO:: Import from file csv/xlsx');
     }
 
+    #[Route('recruitments', name: 'recruitment_list', methods: ['GET'])]
+    public function recruitmentList(Larp $larp, StoryRecruitmentRepository $recruitmentRepository): Response
+    {
+        $recruitments = $recruitmentRepository->createQueryBuilder('r')
+            ->join('r.storyObject', 'o')
+            ->andWhere('o INSTANCE OF ' . Quest::class)
+            ->andWhere('o.larp = :larp')
+            ->setParameter('larp', $larp)
+            ->getQuery()
+            ->getResult();
+
+        return $this->render('backoffice/larp/recruitment/list.html.twig', [
+            'recruitments' => $recruitments,
+            'larp' => $larp,
+            'modify_route' => 'backoffice_larp_story_quest_recruitment',
+        ]);
+    }
+
+    #[Route('recruitment/{recruitment}/proposals', name: 'proposal_list', methods: ['GET'])]
+    public function proposalList(StoryRecruitment $recruitment): Response
+    {
+        return $this->render('backoffice/larp/proposal/list.html.twig', [
+            'proposals' => $recruitment->getProposals(),
+            'larp' => $recruitment->getStoryObject()->getLarp(),
+            'accept_route' => 'backoffice_larp_story_quest_proposal_accept',
+            'reject_route' => 'backoffice_larp_story_quest_proposal_reject',
+        ]);
+    }
+
     #[Route('{quest}/recruitment', name: 'recruitment', defaults: ['recruitment' => null], methods: ['GET', 'POST'])]
     public function recruitment(
         Request                    $request,

--- a/src/Controller/Backoffice/Story/ThreadController.php
+++ b/src/Controller/Backoffice/Story/ThreadController.php
@@ -156,6 +156,35 @@ class ThreadController extends BaseController
         return new Response('TODO:: Import from file csv/xlsx');
     }
 
+    #[Route('recruitments', name: 'recruitment_list', methods: ['GET'])]
+    public function recruitmentList(Larp $larp, StoryRecruitmentRepository $recruitmentRepository): Response
+    {
+        $recruitments = $recruitmentRepository->createQueryBuilder('r')
+            ->join('r.storyObject', 'o')
+            ->andWhere('o INSTANCE OF ' . Thread::class)
+            ->andWhere('o.larp = :larp')
+            ->setParameter('larp', $larp)
+            ->getQuery()
+            ->getResult();
+
+        return $this->render('backoffice/larp/recruitment/list.html.twig', [
+            'recruitments' => $recruitments,
+            'larp' => $larp,
+            'modify_route' => 'backoffice_larp_story_thread_recruitment',
+        ]);
+    }
+
+    #[Route('recruitment/{recruitment}/proposals', name: 'proposal_list', methods: ['GET'])]
+    public function proposalList(StoryRecruitment $recruitment): Response
+    {
+        return $this->render('backoffice/larp/proposal/list.html.twig', [
+            'proposals' => $recruitment->getProposals(),
+            'larp' => $recruitment->getStoryObject()->getLarp(),
+            'accept_route' => 'backoffice_larp_story_thread_proposal_accept',
+            'reject_route' => 'backoffice_larp_story_thread_proposal_reject',
+        ]);
+    }
+
     #[Route('{thread}/recruitment', name: 'recruitment', defaults: ['recruitment' => null], methods: ['GET', 'POST'])]
     public function recruitment(
         Request                    $request,


### PR DESCRIPTION
## Summary
- extend story controllers to list recruitments and proposals
- reuse typed form classes for recruitment/proposal management

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`


------
https://chatgpt.com/codex/tasks/task_e_684fd1acd5088326b4094395bb6938bf