### PR TITLE
Add StoryRecruitment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,29 @@ yarn dev-server
 yarn build
 ```
 
+## Story recruitment module
+
+### Business purpose
+
+Historia każdego LARPa wymaga konkretnych postaci lub pomocników do
+wypełnienia wydarzeń i wątków. Funkcjonalność **StoryRecruitment** pozwala
+organizatorom określić zapotrzebowanie na uczestników (liczbę i typ roli) oraz
+zbierać zgłoszenia od innych fabularzystów (gracze nie mają do tego dostępu).
+Dzięki temu można w jednym miejscu śledzić, kto zaproponował swoją postać i
+czy została ona zaakceptowana.
+
+### Implementation details
+
+* `StoryRecruitment` – encja powiązana z `StoryObject` (np. `Thread`, `Quest`,
+  `Event`). Przechowuje pola `requiredNumber`, `type` i opcjonalne `notes` oraz
+  kolekcję zgłoszeń.
+* `RecruitmentProposal` – reprezentuje zgłoszenie konkretnej postaci do
+  rekrutacji i posiada status z wyliczenia
+  `RecruitmentProposalStatus` (`pending`, `accepted`, `rejected`).
+* `StoryRecruitmentType` – formularz do tworzenia i edycji rekrutacji.
+* Kontrolery w katalogu `Backoffice/Story` umożliwiają listowanie rekrutacji,
+  przegląd zgłoszeń oraz akceptację lub odrzucanie propozycji.
+
+Podobne sekcje w dokumentacji dla innych modułów ułatwiają szybkie poznanie
+ich roli i głównych klas.
+


### PR DESCRIPTION
## Summary
- document the business reason and implementation of StoryRecruitment in README
- clarify that players cannot submit StoryRecruitment proposals

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: No such file or directory)*
- `vendor/bin/ecs check` *(fails: No such file or directory)*
- `vendor/bin/phpstan analyse -c phpstan.neon` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684fd3b6e6448326abaf347f2e802f79