### PR TITLE
Implement recruitment marketplace

### DIFF
--- a/migrations/Version20250616131736.php
+++ b/migrations/Version20250616131736.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250616131736 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add available_for_recruitment column to larp_character table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_character ADD available_for_recruitment BOOLEAN NOT NULL DEFAULT FALSE
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE larp_character DROP available_for_recruitment
+        SQL);
+    }
+}

--- a/src/Controller/Backoffice/Story/StoryMarketplaceController.php
+++ b/src/Controller/Backoffice/Story/StoryMarketplaceController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Controller\Backoffice\Story;
+
+use App\Controller\BaseController;
+use App\Entity\Larp;
+use App\Entity\StoryObject\LarpCharacter;
+use App\Repository\StoryObject\LarpCharacterRepository;
+use App\Repository\StoryObject\StoryRecruitmentRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/larp/{larp}/story/marketplace/', name: 'backoffice_larp_story_marketplace_')]
+class StoryMarketplaceController extends BaseController
+{
+    #[Route('list', name: 'list', methods: ['GET'])]
+    public function list(Larp $larp, LarpCharacterRepository $repository): Response
+    {
+        $characters = $repository->createQueryBuilder('c')
+            ->andWhere('c.larp = :larp')
+            ->andWhere('c.availableForRecruitment = true')
+            ->setParameter('larp', $larp)
+            ->orderBy('c.title', 'asc')
+            ->getQuery()
+            ->getResult();
+
+        return $this->render('backoffice/larp/marketplace/list.html.twig', [
+            'larp' => $larp,
+            'characters' => $characters,
+        ]);
+    }
+
+    #[Route('toggle/{character}', name: 'toggle', methods: ['POST'])]
+    public function toggle(Larp $larp, LarpCharacter $character, LarpCharacterRepository $repository): Response
+    {
+        $character->setAvailableForRecruitment(!$character->isAvailableForRecruitment());
+        $repository->save($character);
+
+        return $this->redirectToRoute('backoffice_larp_story_marketplace_list', [
+            'larp' => $larp->getId(),
+        ]);
+    }
+
+    #[Route('{character}/recruitments', name: 'recruitments', methods: ['GET'])]
+    public function recruitments(Larp $larp, LarpCharacter $character, StoryRecruitmentRepository $recruitmentRepository): Response
+    {
+        $recruitments = $recruitmentRepository->createQueryBuilder('r')
+            ->join('r.storyObject', 'o')
+            ->andWhere('o.larp = :larp')
+            ->setParameter('larp', $larp)
+            ->getQuery()
+            ->getResult();
+
+        return $this->render('backoffice/larp/marketplace/recruitments.html.twig', [
+            'larp' => $larp,
+            'character' => $character,
+            'recruitments' => $recruitments,
+        ]);
+    }
+}

--- a/src/Entity/StoryObject/LarpCharacter.php
+++ b/src/Entity/StoryObject/LarpCharacter.php
@@ -44,6 +44,9 @@ class LarpCharacter extends StoryObject
     #[ORM\Column(length: 255, nullable: true, enumType: Gender::class)]
     private ?Gender $gender = null;
 
+    #[ORM\Column(type: 'boolean')]
+    private bool $availableForRecruitment = false;
+
     #[ORM\ManyToOne(targetEntity: LarpParticipant::class)]
     #[ORM\JoinColumn(nullable: true)]
     private ?LarpParticipant $storyWriter = null;
@@ -183,6 +186,16 @@ class LarpCharacter extends StoryObject
     {
         $this->gender = $gender;
         return $this;
+    }
+
+    public function isAvailableForRecruitment(): bool
+    {
+        return $this->availableForRecruitment;
+    }
+
+    public function setAvailableForRecruitment(bool $availableForRecruitment): void
+    {
+        $this->availableForRecruitment = $availableForRecruitment;
     }
 
     public function getTags(): Collection

--- a/src/Form/CharacterType.php
+++ b/src/Form/CharacterType.php
@@ -9,6 +9,7 @@ use App\Entity\StoryObject\LarpFaction;
 use App\Repository\StoryObject\LarpFactionRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -39,6 +40,10 @@ class CharacterType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.character.description',
+            ])
+            ->add('availableForRecruitment', CheckboxType::class, [
+                'label' => 'form.character.available_for_recruitment',
+                'required' => false,
             ])
             ->add('factions', EntityType::class, [
                 'class' => LarpFaction::class,

--- a/templates/backoffice/larp/_menu.html.twig
+++ b/templates/backoffice/larp/_menu.html.twig
@@ -56,6 +56,11 @@
                             {{ 'backoffice.larp.character.list'|trans }}
                         </a>
 
+                        <a href="{{ path('backoffice_larp_story_marketplace_list', {'larp': larp.id}) }}"
+                           class="btn btn-primary {% if 'larp_story_marketplace' in currentRoute %}active{% endif %}">
+                            {{ 'backoffice.larp.marketplace'|trans }}
+                        </a>
+
                         <a href="{{ path('backoffice_larp_story_faction_list', {'larp': larp.id}) }}"
                            class="btn btn-primary {% if 'larp_story_faction' in currentRoute %}active{% endif %}">
                             {{ 'backoffice.larp.faction.list'|trans }}

--- a/templates/backoffice/larp/marketplace/list.html.twig
+++ b/templates/backoffice/larp/marketplace/list.html.twig
@@ -1,0 +1,18 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <h2>{{ 'backoffice.marketplace.available'|trans }}</h2>
+    <ul>
+        {% for character in characters %}
+            <li>
+                {{ character.title }}
+                <form method="post" action="{{ path('backoffice_larp_story_marketplace_toggle', {larp: larp.id, character: character.id}) }}" style="display:inline">
+                    <button class="btn btn-sm btn-secondary" type="submit">{{ 'backoffice.marketplace.toggle'|trans }}</button>
+                </form>
+                <a href="{{ path('backoffice_larp_story_marketplace_recruitments', {larp: larp.id, character: character.id}) }}" class="btn btn-sm btn-primary">{{ 'backoffice.marketplace.view_recruitments'|trans }}</a>
+            </li>
+        {% else %}
+            <li>{{ 'common.empty_list'|trans }}</li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/templates/backoffice/larp/marketplace/recruitments.html.twig
+++ b/templates/backoffice/larp/marketplace/recruitments.html.twig
@@ -1,0 +1,12 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <h2>{{ 'backoffice.recruitment.open'|trans }}</h2>
+    <ul>
+        {% for recruitment in recruitments %}
+            <li>{{ recruitment.type }} ({{ recruitment.requiredNumber }})</li>
+        {% else %}
+            <li>{{ 'backoffice.recruitment.none'|trans }}</li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -5,6 +5,7 @@ form:
     name: "Unique Character Name"
     in_game_name: "In-Game Name"
     description: "Character Description"
+    available_for_recruitment: "Available for recruitment"
     faction: "Faction"
     choose_faction: "Choose a faction..."
   faction:

--- a/translations/forms.pl.yaml
+++ b/translations/forms.pl.yaml
@@ -13,3 +13,5 @@ form:
   proposal:
     character: "Postać"
     comment: "Komentarz"
+  character:
+    available_for_recruitment: "Dostępny do rekrutacji"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -118,6 +118,7 @@ backoffice:
       title: 'Select files to share with LARPPilot'
       open_picker_desc: 'Open the google file picker to choose files You want to share with LarpPilot'
     threads: 'Threads'
+    marketplace: 'Marketplace'
     submissions:
       title: 'Character Submissions'
       missing: 'Characters without submissions: %count%'
@@ -145,6 +146,10 @@ backoffice:
   recruitment:
     open: "Open recruitments"
     none: "No recruitments"
+  marketplace:
+    available: "Available Characters"
+    toggle: "Toggle"
+    view_recruitments: "View Recruitments"
   proposal:
     list: "Proposals"
     accept: "Accept"

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -75,6 +75,7 @@ backoffice:
       delete_title: Usuń postać "%name%"?
       delete_only_larpilot: Usuń tylko w LARPilot
       delete_larpilot_and_integrations: Usuń w LARPilot oraz wszystkich powiązanych integracjach
+    marketplace: Marketplace
     factions: Frakcje
     quests: Zadania
     relations: Powiązania
@@ -110,6 +111,10 @@ backoffice:
   recruitment:
     open: "Otwarte rekrutacje"
     none: "Brak rekrutacji"
+  marketplace:
+    available: "Dostępne postacie"
+    toggle: "Przełącz"
+    view_recruitments: "Zobacz rekrutacje"
   proposal:
     list: "Propozycje"
     accept: "Akceptuj"


### PR DESCRIPTION
## Summary
- extend `LarpCharacter` with `availableForRecruitment`
- handle the new field in `CharacterType` form
- add `StoryMarketplaceController` with list/toggle/recruitments actions
- provide marketplace templates and navigation entry
- update translations
- add migration

## Testing
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_685018d1a9b88326aac13e21f163d382