### PR TITLE
Add recruitment proposal form

### DIFF
--- a/src/Controller/Backoffice/Story/EventsController.php
+++ b/src/Controller/Backoffice/Story/EventsController.php
@@ -10,6 +10,7 @@ use App\Entity\StoryObject\RecruitmentProposal;
 use App\Entity\StoryObject\StoryRecruitment;
 use App\Form\EventType;
 use App\Form\Filter\EventFilterType;
+use App\Form\RecruitmentProposalType;
 use App\Form\StoryRecruitmentType;
 use App\Helper\Logger;
 use App\Repository\StoryObject\EventRepository;
@@ -129,6 +130,7 @@ class EventsController extends BaseController
             'recruitments' => $recruitments,
             'larp' => $larp,
             'modify_route' => 'backoffice_larp_story_event_recruitment',
+            'proposal_route' => 'backoffice_larp_story_event_proposal',
         ]);
     }
 
@@ -140,6 +142,36 @@ class EventsController extends BaseController
             'larp' => $recruitment->getStoryObject()->getLarp(),
             'accept_route' => 'backoffice_larp_story_event_proposal_accept',
             'reject_route' => 'backoffice_larp_story_event_proposal_reject',
+            'create_route' => 'backoffice_larp_story_event_proposal',
+            'recruitment' => $recruitment,
+        ]);
+    }
+
+    #[Route('recruitment/{recruitment}/proposal', name: 'proposal', methods: ['GET', 'POST'])]
+    public function proposal(
+        Request                      $request,
+        Larp                         $larp,
+        StoryRecruitment             $recruitment,
+        RecruitmentProposalRepository $proposalRepository,
+    ): Response {
+        $proposal = new RecruitmentProposal();
+        $proposal->setRecruitment($recruitment);
+
+        $form = $this->createForm(RecruitmentProposalType::class, $proposal, ['larp' => $larp]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $proposalRepository->save($proposal);
+
+            return $this->redirectToRoute('backoffice_larp_story_event_proposal_list', [
+                'larp' => $larp->getId(),
+                'recruitment' => $recruitment->getId(),
+            ]);
+        }
+
+        return $this->render('backoffice/larp/proposal/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
         ]);
     }
 

--- a/src/Controller/Backoffice/Story/QuestController.php
+++ b/src/Controller/Backoffice/Story/QuestController.php
@@ -11,6 +11,7 @@ use App\Entity\StoryObject\StoryObject;
 use App\Entity\StoryObject\StoryRecruitment;
 use App\Form\Filter\QuestFilterType;
 use App\Form\QuestType;
+use App\Form\RecruitmentProposalType;
 use App\Form\StoryRecruitmentType;
 use App\Helper\Logger;
 use App\Repository\StoryObject\QuestRepository;
@@ -149,6 +150,7 @@ class QuestController extends BaseController
             'recruitments' => $recruitments,
             'larp' => $larp,
             'modify_route' => 'backoffice_larp_story_quest_recruitment',
+            'proposal_route' => 'backoffice_larp_story_quest_proposal',
         ]);
     }
 
@@ -160,6 +162,36 @@ class QuestController extends BaseController
             'larp' => $recruitment->getStoryObject()->getLarp(),
             'accept_route' => 'backoffice_larp_story_quest_proposal_accept',
             'reject_route' => 'backoffice_larp_story_quest_proposal_reject',
+            'create_route' => 'backoffice_larp_story_quest_proposal',
+            'recruitment' => $recruitment,
+        ]);
+    }
+
+    #[Route('recruitment/{recruitment}/proposal', name: 'proposal', methods: ['GET', 'POST'])]
+    public function proposal(
+        Request                      $request,
+        Larp                         $larp,
+        StoryRecruitment             $recruitment,
+        RecruitmentProposalRepository $proposalRepository,
+    ): Response {
+        $proposal = new RecruitmentProposal();
+        $proposal->setRecruitment($recruitment);
+
+        $form = $this->createForm(RecruitmentProposalType::class, $proposal, ['larp' => $larp]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $proposalRepository->save($proposal);
+
+            return $this->redirectToRoute('backoffice_larp_story_quest_proposal_list', [
+                'larp' => $larp->getId(),
+                'recruitment' => $recruitment->getId(),
+            ]);
+        }
+
+        return $this->render('backoffice/larp/proposal/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
         ]);
     }
 

--- a/src/Controller/Backoffice/Story/ThreadController.php
+++ b/src/Controller/Backoffice/Story/ThreadController.php
@@ -9,6 +9,7 @@ use App\Entity\StoryObject\RecruitmentProposal;
 use App\Entity\StoryObject\StoryRecruitment;
 use App\Entity\StoryObject\Thread;
 use App\Form\Filter\ThreadFilterType;
+use App\Form\RecruitmentProposalType;
 use App\Form\StoryRecruitmentType;
 use App\Form\ThreadType;
 use App\Helper\Logger;
@@ -150,6 +151,7 @@ class ThreadController extends BaseController
             'recruitments' => $recruitments,
             'larp' => $larp,
             'modify_route' => 'backoffice_larp_story_thread_recruitment',
+            'proposal_route' => 'backoffice_larp_story_thread_proposal',
         ]);
     }
 
@@ -161,6 +163,36 @@ class ThreadController extends BaseController
             'larp' => $recruitment->getStoryObject()->getLarp(),
             'accept_route' => 'backoffice_larp_story_thread_proposal_accept',
             'reject_route' => 'backoffice_larp_story_thread_proposal_reject',
+            'create_route' => 'backoffice_larp_story_thread_proposal',
+            'recruitment' => $recruitment,
+        ]);
+    }
+
+    #[Route('recruitment/{recruitment}/proposal', name: 'proposal', methods: ['GET', 'POST'])]
+    public function proposal(
+        Request                      $request,
+        Larp                         $larp,
+        StoryRecruitment             $recruitment,
+        RecruitmentProposalRepository $proposalRepository,
+    ): Response {
+        $proposal = new RecruitmentProposal();
+        $proposal->setRecruitment($recruitment);
+
+        $form = $this->createForm(RecruitmentProposalType::class, $proposal, ['larp' => $larp]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $proposalRepository->save($proposal);
+
+            return $this->redirectToRoute('backoffice_larp_story_thread_proposal_list', [
+                'larp' => $larp->getId(),
+                'recruitment' => $recruitment->getId(),
+            ]);
+        }
+
+        return $this->render('backoffice/larp/proposal/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
         ]);
     }
 

--- a/templates/backoffice/larp/proposal/list.html.twig
+++ b/templates/backoffice/larp/proposal/list.html.twig
@@ -2,6 +2,11 @@
 
 {% block larp_content %}
     <h2>{{ 'backoffice.proposal.list'|trans }}</h2>
+    {% if create_route is defined %}
+        <a href="{{ path(create_route, { larp: larp.id, recruitment: recruitment.id }) }}" class="btn btn-success mb-3">
+            {{ 'backoffice.proposal.create'|trans }}
+        </a>
+    {% endif %}
     <ul>
         {% for proposal in proposals %}
             <li>{{ proposal.character.title }} - {{ proposal.status.value }}

--- a/templates/backoffice/larp/proposal/modify.html.twig
+++ b/templates/backoffice/larp/proposal/modify.html.twig
@@ -1,0 +1,7 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    {{ form_start(form) }}
+    {{ form_widget(form) }}
+    {{ form_end(form) }}
+{% endblock %}

--- a/templates/backoffice/larp/recruitment/list.html.twig
+++ b/templates/backoffice/larp/recruitment/list.html.twig
@@ -7,6 +7,11 @@
             <li>
                 {{ recruitment.type }} ({{ recruitment.requiredNumber }})
                 <a href="{{ path(modify_route, {larp: larp.id, id: recruitment.id}) }}" class="btn btn-sm btn-secondary">{{ 'common.edit'|trans }}</a>
+                {% if proposal_route is defined %}
+                    <a href="{{ path(proposal_route, {larp: larp.id, recruitment: recruitment.id}) }}" class="btn btn-sm btn-primary">
+                        {{ 'backoffice.proposal.create'|trans }}
+                    </a>
+                {% endif %}
             </li>
         {% else %}
             <li>{{ 'backoffice.recruitment.none'|trans }}</li>

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -115,6 +115,7 @@ backoffice:
     accept: "Annehmen"
     reject: "Ablehnen"
     none: "Keine Vorschläge"
+    create: "Vorschlag erstellen"
 # Konto-bezogene Übersetzungen
 account:
   larp:

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -155,6 +155,7 @@ backoffice:
     accept: "Accept"
     reject: "Reject"
     none: "No proposals"
+    create: "Create Proposal"
 #Account related translations for both player and organizers
 account:
   larp:

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -120,6 +120,7 @@ backoffice:
     accept: "Akceptuj"
     reject: "Odrzuć"
     none: "Brak propozycji"
+    create: "Utwórz propozycję"
 
 # Tłumaczenia konta gracza/organizatora
 account:


### PR DESCRIPTION
## Summary
- allow adding recruitment proposals for events, quests and threads
- render create proposal links on recruitment and proposal lists
- translate the new "Create Proposal" button in EN/PL/DE
- add form template for creating proposals

## Testing
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68501c45fb208326a9a53df62d600262