### PR TITLE
Add Tag management system

### DIFF
--- a/src/Controller/Backoffice/Story/TagController.php
+++ b/src/Controller/Backoffice/Story/TagController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Controller\Backoffice\Story;
+
+use App\Controller\BaseController;
+use App\Entity\Larp;
+use App\Entity\Tag;
+use App\Form\Filter\TagFilterType;
+use App\Form\TagType;
+use App\Repository\TagRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/larp/{larp}/story/tag/', name: 'backoffice_larp_story_tag_')]
+class TagController extends BaseController
+{
+    #[Route('list', name: 'list', methods: ['GET', 'POST'])]
+    public function list(Request $request, Larp $larp, TagRepository $repository): Response
+    {
+        $filterForm = $this->createForm(TagFilterType::class);
+        $filterForm->handleRequest($request);
+        $qb = $repository->createQueryBuilder('t');
+        $this->filterBuilderUpdater->addFilterConditions($filterForm, $qb);
+        $sort = $request->query->get('sort', 'name');
+        $dir = $request->query->get('dir', 'asc');
+        $qb->orderBy('t.' . $sort, $dir);
+        $qb->andWhere('t.larp = :larp')->setParameter('larp', $larp);
+
+        return $this->render('backoffice/larp/tag/list.html.twig', [
+            'filterForm' => $filterForm->createView(),
+            'tags' => $qb->getQuery()->getResult(),
+            'larp' => $larp,
+        ]);
+    }
+
+    #[Route('{tag}', name: 'modify', defaults: ['tag' => null], methods: ['GET', 'POST'])]
+    public function modify(Request $request, Larp $larp, TagRepository $tagRepository, ?Tag $tag = null): Response
+    {
+        if (!$tag) {
+            $tag = new Tag();
+            $tag->setLarp($larp);
+        }
+
+        $form = $this->createForm(TagType::class, $tag);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $tagRepository->save($tag);
+            $this->addFlash('success', $this->translator->trans('backoffice.common.success_save'));
+
+            return $this->redirectToRoute('backoffice_larp_story_tag_list', ['larp' => $larp->getId()]);
+        }
+
+        return $this->render('backoffice/larp/tag/modify.html.twig', [
+            'form' => $form->createView(),
+            'larp' => $larp,
+            'tag' => $tag,
+        ]);
+    }
+
+    #[Route('{tag}/delete', name: 'delete', methods: ['GET', 'POST'])]
+    public function delete(Larp $larp, TagRepository $tagRepository, Tag $tag): Response
+    {
+        $tagRepository->remove($tag);
+        $this->addFlash('success', $this->translator->trans('backoffice.common.success_delete'));
+
+        return $this->redirectToRoute('backoffice_larp_story_tag_list', ['larp' => $larp->getId()]);
+    }
+}

--- a/src/Form/Filter/TagFilterType.php
+++ b/src/Form/Filter/TagFilterType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Form\Filter;
+
+use App\Entity\Enum\TargetType;
+use Spiriit\Bundle\FormFilterBundle\Filter\FilterOperands;
+use Spiriit\Bundle\FormFilterBundle\Filter\Form\Type as Filters;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TagFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', Filters\TextFilterType::class, [
+                'condition_pattern' => FilterOperands::STRING_CONTAINS,
+            ])
+            ->add('target', Filters\EnumFilterType::class, [
+                'class' => TargetType::class,
+                'required' => false,
+                'multiple' => true,
+                'autocomplete' => true,
+                'placeholder' => 'form.choose',
+            ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'tag_filter';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'validation_groups' => ['filtering'],
+            'method' => 'GET',
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Form/TagType.php
+++ b/src/Form/TagType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Enum\TargetType;
+use App\Entity\Tag;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TagType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'form.tag.name',
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'form.tag.description',
+                'required' => false,
+            ])
+            ->add('target', ChoiceType::class, [
+                'label' => 'form.tag.target',
+                'choices' => TargetType::cases(),
+                'choice_label' => fn (TargetType $type) => $type->name,
+                'choice_value' => fn (?TargetType $type) => $type?->value,
+                'placeholder' => 'form.choose',
+                'required' => false,
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.submit',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Tag::class,
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Tag;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends BaseRepository<Tag>
+ */
+class TagRepository extends BaseRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Tag::class);
+    }
+}

--- a/templates/backoffice/larp/_menu.html.twig
+++ b/templates/backoffice/larp/_menu.html.twig
@@ -95,6 +95,11 @@
                            class="btn btn-primary {% if 'larp_story_item' in currentRoute %}active{% endif %}">
                             {{ 'backoffice.larp.item.list'|trans }}
                         </a>
+
+                        <a href="{{ path('backoffice_larp_story_tag_list', {'larp': larp.id}) }}"
+                           class="btn btn-primary {% if 'larp_story_tag' in currentRoute %}active{% endif %}">
+                            {{ 'backoffice.larp.tag.list'|trans }}
+                        </a>
                     </div>
                 {% endif %}
             </div>

--- a/templates/backoffice/larp/tag/list.html.twig
+++ b/templates/backoffice/larp/tag/list.html.twig
@@ -1,0 +1,87 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <div class="card mt-4">
+        <div class="card-header">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="mb-0">{{ 'backoffice.larp.tag.list'|trans }}</h2>
+                <div class="d-flex gap-2">
+                    <a href="{{ path('backoffice_larp_story_tag_modify', { larp: larp.id }) }}" class="btn btn-success">
+                        {{ 'common.create'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="card-body p-0">
+            {% include 'includes/filter_form.html.twig' with { form: filterForm } %}
+
+            <table class="table table-striped table-hover mb-0">
+                <thead class="table-light">
+                <tr>
+                    {% include 'includes/sort_th.html.twig' with { field: 'name', label: 'common.name'|trans } %}
+                    <th>{{ 'common.description'|trans }}</th>
+                    <th>{{ 'common.actions'|trans }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for tag in tags %}
+                    <tr>
+                        <td>{{ tag.name }}</td>
+                        <td>{{ tag.description|default('-') }}</td>
+                        <td>
+                            <a href="{{ path('backoffice_larp_story_tag_modify', { larp: larp.id, tag: tag.id }) }}"
+                               class="btn btn-sm btn-primary">
+                                {{ 'common.show_edit'|trans }}
+                            </a>
+                            <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal"
+                                    data-bs-target="#globalDeleteTagModal"
+                                    data-delete-text=" {{ 'common.delete'|trans }}"
+                                    data-character-id="{{ tag.id }}" data-character-name="{{ tag.name }}"
+                                    data-delete-url-base="{{ path('backoffice_larp_story_tag_delete', { larp: larp.id, tag: 'CHARACTER_ID' }) }}">
+                                {{ 'common.delete'|trans }}
+                            </button>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="modal fade" id="globalDeleteTagModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="globalDeleteTagModalLabel"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'common.close'|trans }}"></button>
+                </div>
+                <div class="modal-body">
+                    {{ 'backoffice.common.confirmation'|trans() }}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        {{ 'common.cancel'|trans }}
+                    </button>
+                    <a href="#" id="deleteOnlyLarpilot" class="btn btn-danger">
+                        {{ 'backoffice.larp.tag.delete_only_larpilot'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const deleteModal = document.getElementById('globalDeleteTagModal');
+        deleteModal.addEventListener('show.bs.modal', function (event) {
+            const button = event.relatedTarget;
+            const characterId = button.getAttribute('data-character-id');
+            const characterName = button.getAttribute('data-character-name');
+            const baseUrl = button.getAttribute('data-delete-url-base');
+            const deleteTxt = button.getAttribute('data-delete-text');
+            const modalTitle = deleteModal.querySelector('.modal-title');
+            modalTitle.textContent = `${deleteTxt} "${characterName}"?`;
+            const deleteOnlyLink = document.getElementById('deleteOnlyLarpilot');
+            deleteOnlyLink.href = baseUrl.replace('CHARACTER_ID', characterId).replace('INTEGRATIONS_FLAG', 'false');
+        });
+    </script>
+{% endblock %}

--- a/templates/backoffice/larp/tag/modify.html.twig
+++ b/templates/backoffice/larp/tag/modify.html.twig
@@ -1,0 +1,9 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <div>
+        {{ form_start(form) }}
+        {{ form_widget(form) }}
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -74,6 +74,10 @@ form:
     is_purchased: "Purchased"
     quantity: "Quantity"
     cost: "Cost"
+  tag:
+    name: "Tag Name"
+    description: "Tag Description"
+    target: "Target"
   event:
     name: "Event Name"
     description: "Event Description"


### PR DESCRIPTION
## Summary
- add `TagRepository`
- build `TagType` form and `TagFilterType`
- implement `TagController` with CRUD actions
- include new tag templates and menu entry
- update translations
- run tests & static analysis

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`


------
https://chatgpt.com/codex/tasks/task_e_68502ad04dd48326896bae976b0cdcd9