### PR TITLE
Add tag-based SuggestionService

### DIFF
--- a/src/Service/Larp/SuggestionService.php
+++ b/src/Service/Larp/SuggestionService.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Service\Larp;
+
+use App\Entity\StoryObject\Event;
+use App\Entity\StoryObject\LarpCharacter;
+use App\Entity\StoryObject\Quest;
+use App\Entity\StoryObject\Thread;
+use App\Repository\StoryObject\EventRepository;
+use App\Repository\StoryObject\LarpCharacterRepository;
+use App\Repository\StoryObject\QuestRepository;
+use App\Repository\StoryObject\ThreadRepository;
+use Doctrine\Common\Collections\Collection;
+
+readonly class SuggestionService
+{
+    public function __construct(
+        private LarpCharacterRepository $characterRepository,
+        private QuestRepository $questRepository,
+        private EventRepository $eventRepository,
+        private ThreadRepository $threadRepository,
+    ) {
+    }
+
+    /**
+     * @return LarpCharacter[]
+     */
+    public function suggestCharactersForQuest(Quest $quest): array
+    {
+        $tagIds = $this->collectTagIds($quest->getInvolvedCharacters());
+        if ($tagIds === []) {
+            return [];
+        }
+
+        $qb = $this->characterRepository->createQueryBuilder('c');
+        $qb->innerJoin('c.tags', 't')
+            ->andWhere('c.larp = :larp')
+            ->andWhere('t.id IN (:tags)')
+            ->setParameter('larp', $quest->getLarp())
+            ->setParameter('tags', $tagIds)
+            ->addOrderBy('c.title', 'ASC');
+
+        if (!$quest->getInvolvedCharacters()->isEmpty()) {
+            $qb->andWhere('c NOT IN (:involved)')
+                ->setParameter('involved', $quest->getInvolvedCharacters());
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return LarpCharacter[]
+     */
+    public function suggestCharactersForEvent(Event $event): array
+    {
+        $tagIds = $this->collectTagIds($event->getInvolvedCharacters());
+        if ($tagIds === []) {
+            return [];
+        }
+
+        $qb = $this->characterRepository->createQueryBuilder('c');
+        $qb->innerJoin('c.tags', 't')
+            ->andWhere('c.larp = :larp')
+            ->andWhere('t.id IN (:tags)')
+            ->setParameter('larp', $event->getLarp())
+            ->setParameter('tags', $tagIds)
+            ->addOrderBy('c.title', 'ASC');
+
+        if (!$event->getInvolvedCharacters()->isEmpty()) {
+            $qb->andWhere('c NOT IN (:involved)')
+                ->setParameter('involved', $event->getInvolvedCharacters());
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return LarpCharacter[]
+     */
+    public function suggestCharactersForThread(Thread $thread): array
+    {
+        $characters = $thread->getInvolvedCharacters()->toArray();
+        foreach ($thread->getQuests() as $quest) {
+            $characters = array_merge($characters, $quest->getInvolvedCharacters()->toArray());
+        }
+        foreach ($thread->getEvents() as $event) {
+            $characters = array_merge($characters, $event->getInvolvedCharacters()->toArray());
+        }
+
+        $tagIds = $this->collectTagIds($characters);
+        if ($tagIds === []) {
+            return [];
+        }
+
+        $qb = $this->characterRepository->createQueryBuilder('c');
+        $qb->innerJoin('c.tags', 't')
+            ->andWhere('c.larp = :larp')
+            ->andWhere('t.id IN (:tags)')
+            ->setParameter('larp', $thread->getLarp())
+            ->setParameter('tags', $tagIds)
+            ->addOrderBy('c.title', 'ASC');
+
+        if (!empty($characters)) {
+            $qb->andWhere('c NOT IN (:involved)')
+                ->setParameter('involved', $characters);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return Quest[]
+     */
+    public function suggestQuestsForCharacter(LarpCharacter $character): array
+    {
+        $tagIds = $this->collectTagIds([$character]);
+        if ($tagIds === []) {
+            return [];
+        }
+
+        $qb = $this->questRepository->createQueryBuilder('q');
+        $qb->join('q.involvedCharacters', 'ic')
+            ->join('ic.tags', 't')
+            ->andWhere('q.larp = :larp')
+            ->andWhere('t.id IN (:tags)')
+            ->andWhere(':char NOT MEMBER OF q.involvedCharacters')
+            ->setParameter('larp', $character->getLarp())
+            ->setParameter('tags', $tagIds)
+            ->setParameter('char', $character)
+            ->addOrderBy('q.title', 'ASC');
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param iterable<LarpCharacter> $characters
+     * @return string[]
+     */
+    private function collectTagIds(iterable $characters): array
+    {
+        $ids = [];
+        foreach ($characters as $character) {
+            foreach ($character->getTags() as $tag) {
+                $ids[] = $tag->getId()->toRfc4122();
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}


### PR DESCRIPTION
## Summary
- add SuggestionService for characters and quests/events/threads

## Testing
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68504c9253048326b295e7cec295bd1c