### PR TITLE
Add tagging to Event, Quest and Thread

### DIFF
--- a/migrations/Version20250616150000.php
+++ b/migrations/Version20250616150000.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250616150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add tag relations to event, quest and thread';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE event_tags (event_id UUID NOT NULL, tag_id UUID NOT NULL, PRIMARY KEY(event_id, tag_id))
+        SQL);
+        $this->addSql("CREATE INDEX IDX_EVENT_TAGS_EVENT_ID ON event_tags (event_id)");
+        $this->addSql("CREATE INDEX IDX_EVENT_TAGS_TAG_ID ON event_tags (tag_id)");
+        $this->addSql("COMMENT ON COLUMN event_tags.event_id IS '(DC2Type:uuid)'");
+        $this->addSql("COMMENT ON COLUMN event_tags.tag_id IS '(DC2Type:uuid)'");
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE quest_tags (quest_id UUID NOT NULL, tag_id UUID NOT NULL, PRIMARY KEY(quest_id, tag_id))
+        SQL);
+        $this->addSql("CREATE INDEX IDX_QUEST_TAGS_QUEST_ID ON quest_tags (quest_id)");
+        $this->addSql("CREATE INDEX IDX_QUEST_TAGS_TAG_ID ON quest_tags (tag_id)");
+        $this->addSql("COMMENT ON COLUMN quest_tags.quest_id IS '(DC2Type:uuid)'");
+        $this->addSql("COMMENT ON COLUMN quest_tags.tag_id IS '(DC2Type:uuid)'");
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE thread_tags (thread_id UUID NOT NULL, tag_id UUID NOT NULL, PRIMARY KEY(thread_id, tag_id))
+        SQL);
+        $this->addSql("CREATE INDEX IDX_THREAD_TAGS_THREAD_ID ON thread_tags (thread_id)");
+        $this->addSql("CREATE INDEX IDX_THREAD_TAGS_TAG_ID ON thread_tags (tag_id)");
+        $this->addSql("COMMENT ON COLUMN thread_tags.thread_id IS '(DC2Type:uuid)'");
+        $this->addSql("COMMENT ON COLUMN thread_tags.tag_id IS '(DC2Type:uuid)'");
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event_tags ADD CONSTRAINT FK_EVENT_TAGS_EVENT_ID FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event_tags ADD CONSTRAINT FK_EVENT_TAGS_TAG_ID FOREIGN KEY (tag_id) REFERENCES tag (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest_tags ADD CONSTRAINT FK_QUEST_TAGS_QUEST_ID FOREIGN KEY (quest_id) REFERENCES quest (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest_tags ADD CONSTRAINT FK_QUEST_TAGS_TAG_ID FOREIGN KEY (tag_id) REFERENCES tag (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread_tags ADD CONSTRAINT FK_THREAD_TAGS_THREAD_ID FOREIGN KEY (thread_id) REFERENCES thread (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread_tags ADD CONSTRAINT FK_THREAD_TAGS_TAG_ID FOREIGN KEY (tag_id) REFERENCES tag (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event_tags DROP CONSTRAINT FK_EVENT_TAGS_EVENT_ID
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE event_tags DROP CONSTRAINT FK_EVENT_TAGS_TAG_ID
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest_tags DROP CONSTRAINT FK_QUEST_TAGS_QUEST_ID
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE quest_tags DROP CONSTRAINT FK_QUEST_TAGS_TAG_ID
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread_tags DROP CONSTRAINT FK_THREAD_TAGS_THREAD_ID
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE thread_tags DROP CONSTRAINT FK_THREAD_TAGS_TAG_ID
+        SQL);
+        $this->addSql("DROP TABLE event_tags");
+        $this->addSql("DROP TABLE quest_tags");
+        $this->addSql("DROP TABLE thread_tags");
+    }
+}
+

--- a/src/Entity/StoryObject/Event.php
+++ b/src/Entity/StoryObject/Event.php
@@ -6,6 +6,7 @@ use App\Entity\Enum\StoryTimeUnit;
 use App\Entity\Enum\TargetType;
 use App\Entity\LarpParticipant;
 use App\Entity\StoryObject\Place;
+use App\Entity\Tag;
 use App\Repository\StoryObject\EventRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -26,6 +27,11 @@ class Event extends StoryObject
     /** @var Collection<LarpFaction> Specifically needed involved factions */
     #[ORM\ManyToMany(targetEntity: LarpFaction::class)]
     private Collection $involvedFactions;
+
+    /** @var Collection<Tag> */
+    #[ORM\ManyToMany(targetEntity: Tag::class)]
+    #[ORM\JoinTable(name: 'event_tags')]
+    private Collection $tags;
 
     #[ORM\ManyToOne(targetEntity: Thread::class, inversedBy: 'events')]
     #[ORM\JoinColumn(nullable: true)]
@@ -56,6 +62,7 @@ class Event extends StoryObject
         $this->techParticipants = new ArrayCollection();
         $this->involvedCharacters = new ArrayCollection();
         $this->involvedFactions = new ArrayCollection();
+        $this->tags = new ArrayCollection();
     }
 
     public function getTechParticipants(): Collection
@@ -188,6 +195,27 @@ class Event extends StoryObject
     public function setEndTime(?\DateTimeInterface $endTime): void
     {
         $this->endTime = $endTime;
+    }
+
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(Tag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags->add($tag);
+        }
+
+        return $this;
+    }
+
+    public function removeTag(Tag $tag): self
+    {
+        $this->tags->removeElement($tag);
+
+        return $this;
     }
 
 

--- a/src/Entity/StoryObject/Quest.php
+++ b/src/Entity/StoryObject/Quest.php
@@ -4,6 +4,7 @@ namespace App\Entity\StoryObject;
 
 use App\Entity\Enum\TargetType;
 use App\Entity\Larp;
+use App\Entity\Tag;
 use App\Repository\StoryObject\QuestRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -26,6 +27,11 @@ class Quest extends StoryObject
     #[ORM\ManyToMany(targetEntity: LarpFaction::class, mappedBy: 'quests')]
     private Collection $involvedFactions;
 
+    /** @var Collection<Tag> */
+    #[ORM\ManyToMany(targetEntity: Tag::class)]
+    #[ORM\JoinTable(name: 'quest_tags')]
+    private Collection $tags;
+
     #[ORM\Column(type: Types::JSON, nullable: true, options: ['jsonb' => true])]
     private ?array $decisionTree = null;
 
@@ -34,6 +40,7 @@ class Quest extends StoryObject
         parent::__construct();
         $this->involvedFactions = new ArrayCollection();
         $this->involvedCharacters = new ArrayCollection();
+        $this->tags = new ArrayCollection();
     }
 
     public function getThread(): ?Thread
@@ -106,6 +113,27 @@ class Quest extends StoryObject
     public function setDecisionTree(?array $decisionTree): self
     {
         $this->decisionTree = $decisionTree;
+        return $this;
+    }
+
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(Tag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags->add($tag);
+        }
+
+        return $this;
+    }
+
+    public function removeTag(Tag $tag): self
+    {
+        $this->tags->removeElement($tag);
+
         return $this;
     }
 

--- a/src/Entity/StoryObject/Thread.php
+++ b/src/Entity/StoryObject/Thread.php
@@ -4,6 +4,7 @@ namespace App\Entity\StoryObject;
 
 use App\Entity\Enum\TargetType;
 use App\Entity\Larp;
+use App\Entity\Tag;
 use App\Repository\StoryObject\ThreadRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -29,6 +30,11 @@ class Thread extends StoryObject
     #[ORM\ManyToMany(targetEntity: LarpFaction::class, mappedBy: 'threads')]
     private Collection $involvedFactions;
 
+    /** @var Collection<Tag> */
+    #[ORM\ManyToMany(targetEntity: Tag::class)]
+    #[ORM\JoinTable(name: 'thread_tags')]
+    private Collection $tags;
+
     #[ORM\Column(type: Types::JSON, nullable: true, options: ['jsonb' => true])]
     private ?array $decisionTree = null;
 
@@ -39,6 +45,7 @@ class Thread extends StoryObject
         $this->events = new ArrayCollection();
         $this->involvedFactions = new ArrayCollection();
         $this->involvedCharacters = new ArrayCollection();
+        $this->tags = new ArrayCollection();
     }
 
     public function getInvolvedCharacters(): Collection
@@ -122,6 +129,27 @@ class Thread extends StoryObject
     public function setDecisionTree(?array $decisionTree): self
     {
         $this->decisionTree = $decisionTree;
+        return $this;
+    }
+
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(Tag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags->add($tag);
+        }
+
+        return $this;
+    }
+
+    public function removeTag(Tag $tag): self
+    {
+        $this->tags->removeElement($tag);
+
         return $this;
     }
 

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -7,9 +7,11 @@ use App\Entity\StoryObject\Event;
 use App\Entity\StoryObject\LarpCharacter;
 use App\Entity\StoryObject\LarpFaction;
 use App\Entity\StoryObject\Place;
+use App\Entity\Tag;
 use App\Repository\StoryObject\LarpCharacterRepository;
 use App\Repository\StoryObject\LarpFactionRepository;
 use App\Repository\StoryObject\PlaceRepository;
+use App\Repository\TagRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
@@ -82,6 +84,19 @@ class EventType extends AbstractType
                 'query_builder' => function (LarpCharacterRepository $repo) use ($larp) {
                     return $repo->createQueryBuilder('f')
                         ->where('f.larp = :larp')
+                        ->setParameter('larp', $larp);
+                },
+            ])
+            ->add('tags', EntityType::class, [
+                'class' => Tag::class,
+                'choice_label' => 'name',
+                'label' => 'form.event.tags',
+                'required' => false,
+                'multiple' => true,
+                'autocomplete' => true,
+                'query_builder' => function (TagRepository $repo) use ($larp) {
+                    return $repo->createQueryBuilder('t')
+                        ->where('t.larp = :larp')
                         ->setParameter('larp', $larp);
                 },
             ])

--- a/src/Form/QuestType.php
+++ b/src/Form/QuestType.php
@@ -8,9 +8,11 @@ use App\Entity\StoryObject\LarpCharacter;
 use App\Entity\StoryObject\LarpFaction;
 use App\Entity\StoryObject\Quest;
 use App\Entity\StoryObject\Thread;
+use App\Entity\Tag;
 use App\Repository\StoryObject\LarpCharacterRepository;
 use App\Repository\StoryObject\LarpFactionRepository;
 use App\Repository\StoryObject\ThreadRepository;
+use App\Repository\TagRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -80,6 +82,23 @@ class QuestType extends AbstractType
                 'query_builder' => function (LarpCharacterRepository $repo) use ($larp) {
                     return $repo->createQueryBuilder('f')
                         ->where('f.larp = :larp')
+                        ->setParameter('larp', $larp);
+                },
+                'tom_select_options' => [
+                    'create' => true,
+                    'persist' => false,
+                ],
+            ])
+            ->add('tags', EntityType::class, [
+                'class' => Tag::class,
+                'choice_label' => 'name',
+                'label' => 'form.quest.tags',
+                'required' => false,
+                'multiple' => true,
+                'autocomplete' => true,
+                'query_builder' => function (TagRepository $repo) use ($larp) {
+                    return $repo->createQueryBuilder('t')
+                        ->where('t.larp = :larp')
                         ->setParameter('larp', $larp);
                 },
                 'tom_select_options' => [

--- a/src/Form/ThreadType.php
+++ b/src/Form/ThreadType.php
@@ -6,8 +6,10 @@ use App\Entity\Larp;
 use App\Entity\StoryObject\LarpCharacter;
 use App\Entity\StoryObject\LarpFaction;
 use App\Entity\StoryObject\Thread;
+use App\Entity\Tag;
 use App\Repository\StoryObject\LarpCharacterRepository;
 use App\Repository\StoryObject\LarpFactionRepository;
+use App\Repository\TagRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -59,6 +61,23 @@ class ThreadType extends AbstractType
                 'query_builder' => function (LarpCharacterRepository $repo) use ($larp) {
                     return $repo->createQueryBuilder('f')
                         ->where('f.larp = :larp')
+                        ->setParameter('larp', $larp);
+                },
+                'tom_select_options' => [
+                    'create' => true,
+                    'persist' => false,
+                ],
+            ])
+            ->add('tags', EntityType::class, [
+                'class' => Tag::class,
+                'choice_label' => 'name',
+                'label' => 'form.thread.tags',
+                'required' => false,
+                'multiple' => true,
+                'autocomplete' => true,
+                'query_builder' => function (TagRepository $repo) use ($larp) {
+                    return $repo->createQueryBuilder('t')
+                        ->where('t.larp = :larp')
                         ->setParameter('larp', $larp);
                 },
                 'tom_select_options' => [

--- a/translations/forms.en.yaml
+++ b/translations/forms.en.yaml
@@ -46,11 +46,13 @@ form:
     thread: "Assign to Thread"
     factions: "Factions involved in quest"
     characters: "Characters involved in quest"
+    tags: "Tags"
   thread:
     name: "Unique Thread Name"
     description: "Thread Description"
     factions: "Factions involved in thread"
     characters: "Characters involved in thread"
+    tags: "Tags"
   relation:
     name: "Relation Name"
     description: "Description of the relation"
@@ -85,6 +87,7 @@ form:
     choose_place: "Choose a place..."
     factions: "Factions involved in event"
     characters: "Characters involved in event"
+    tags: "Tags"
     start_time: 'Start Time'
     end_time: 'End Time'
     choose_faction: 'Choose a faction...'


### PR DESCRIPTION
## Summary
- allow Events, Quests and Threads to have tags
- expose tag assignment in related forms
- migrate DB to create `event_tags`, `quest_tags` and `thread_tags`

## Testing
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/ecs check`
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_6850468350e88326bdfbe3d42bbfd97e