### PR TITLE
Optimize Doctrine queries

### DIFF
--- a/src/Entity/ExternalReference.php
+++ b/src/Entity/ExternalReference.php
@@ -20,6 +20,7 @@ use Symfony\Component\Uid\Uuid;
 
 #[Gedmo\Loggable]
 #[ORM\Entity(repositoryClass: ExternalReferenceRepository::class)]
+#[ORM\Index(columns: ['created_by_id'])]
 class ExternalReference implements CreatorAwareInterface, Timestampable
 {
     use UuidTraitEntity;

--- a/src/Entity/LarpCharacterSubmission.php
+++ b/src/Entity/LarpCharacterSubmission.php
@@ -15,6 +15,10 @@ use Gedmo\Timestampable\Timestampable;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 
 #[ORM\Entity(repositoryClass: LarpCharacterSubmissionRepository::class)]
+#[ORM\Index(columns: ['larp_id'])]
+#[ORM\Index(columns: ['user_id'])]
+#[ORM\Index(columns: ['preferred_tags_id'])]
+#[ORM\Index(columns: ['unwanted_tags_id'])]
 class LarpCharacterSubmission implements Timestampable, CreatorAwareInterface
 {
     use UuidTraitEntity;

--- a/src/Entity/LarpCharacterSubmissionChoice.php
+++ b/src/Entity/LarpCharacterSubmissionChoice.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
+#[ORM\Index(columns: ['submission_id'])]
+#[ORM\Index(columns: ['character_id'])]
 class LarpCharacterSubmissionChoice
 {
     use UuidTraitEntity;

--- a/src/Entity/LarpIncident.php
+++ b/src/Entity/LarpIncident.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: LarpIncidentRepository::class)]
+#[ORM\Index(columns: ['larp_id'])]
+#[ORM\Index(columns: ['created_by_id'])]
 class LarpIncident implements LarpAwareInterface, CreatorAwareInterface
 {
     use UuidTraitEntity;

--- a/src/Entity/LarpIntegration.php
+++ b/src/Entity/LarpIntegration.php
@@ -14,6 +14,8 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 
 #[ORM\Entity(repositoryClass: LarpIntegrationRepository::class)]
+#[ORM\Index(columns: ['larp_id'])]
+#[ORM\Index(columns: ['created_by_id'])]
 class LarpIntegration implements Timestampable, CreatorAwareInterface
 {
     use UuidTraitEntity;

--- a/src/Entity/LarpInvitation.php
+++ b/src/Entity/LarpInvitation.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 
 #[ORM\Entity(repositoryClass: LarpInvitationRepository::class)]
+#[ORM\Index(columns: ['larp_id'])]
 class LarpInvitation
 {
     use UuidTraitEntity;
@@ -20,7 +21,7 @@ class LarpInvitation
     #[ORM\JoinColumn(nullable: false)]
     private ?Larp $larp = null;
 
-    #[ORM\Column(type: 'string', length: 64)]
+    #[ORM\Column(type: 'string', length: 64, unique: true)]
     private ?string $code = null;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: false)]

--- a/src/Entity/LarpParticipant.php
+++ b/src/Entity/LarpParticipant.php
@@ -15,6 +15,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Entity joining User with Larp and its Character
  */
 #[ORM\Entity(repositoryClass: LarpParticipantRepository::class)]
+#[ORM\Index(columns: ['user_id'])]
+#[ORM\Index(columns: ['larp_id'])]
+#[ORM\Index(columns: ['larp_character_id'])]
 class LarpParticipant
 {
     use UuidTraitEntity;
@@ -140,6 +143,4 @@ class LarpParticipant
     {
         $this->larpCharacterSubmission = $larpCharacterSubmission;
     }
-
-
 }

--- a/src/Entity/ObjectFieldMapping.php
+++ b/src/Entity/ObjectFieldMapping.php
@@ -13,6 +13,9 @@ use Gedmo\Timestampable\Timestampable;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 
 #[ORM\Entity(repositoryClass: ObjectFieldMappingRepository::class)]
+#[ORM\Index(columns: ['larp_id'])]
+#[ORM\Index(columns: ['created_by_id'])]
+#[ORM\Index(columns: ['external_file_id'])]
 class ObjectFieldMapping implements Timestampable, CreatorAwareInterface
 {
     use UuidTraitEntity;

--- a/src/Entity/SavedFormFilter.php
+++ b/src/Entity/SavedFormFilter.php
@@ -14,6 +14,8 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: SavedFormFilterRepository::class)]
+#[ORM\Index(columns: ['larp_id'])]
+#[ORM\Index(columns: ['created_by_id'])]
 class SavedFormFilter implements CreatorAwareInterface, Timestampable, LarpAwareInterface
 {
     use UuidTraitEntity;

--- a/src/Entity/SharedFile.php
+++ b/src/Entity/SharedFile.php
@@ -12,6 +12,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: SharedFileRepository::class)]
+#[ORM\Index(columns: ['integration_id'])]
 class SharedFile
 {
     use UuidTraitEntity;

--- a/src/Service/Larp/SubmissionStatsService.php
+++ b/src/Service/Larp/SubmissionStatsService.php
@@ -5,16 +5,22 @@ namespace App\Service\Larp;
 use App\Entity\Larp;
 use App\Entity\LarpCharacterSubmission;
 use App\Repository\LarpCharacterSubmissionRepository;
+use ShipMonk\DoctrineEntityPreloader\EntityPreloader;
 
 readonly class SubmissionStatsService
 {
-    public function __construct(private LarpCharacterSubmissionRepository $repository)
-    {
+    public function __construct(
+        private LarpCharacterSubmissionRepository $repository,
+        private EntityPreloader $preloader,
+    ) {
     }
 
     public function getStatsForLarp(Larp $larp): array
     {
         $submissions = $this->repository->findBy(['larp' => $larp]);
+        $this->preloader->preload($submissions, 'choices');
+        $this->preloader->preload($submissions, 'choices.character');
+        $this->preloader->preload($larp->getFactions(), 'members');
 
         $charactersWithSubmission = [];
         foreach ($submissions as $submission) {


### PR DESCRIPTION
## Summary
- declare Doctrine indexes for frequently searched columns
- enable preloading of submission-related relations for stats service

## Testing
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68504fdf80908326929d5b8e04413880