### PR TITLE
Implement LARP application forms and matching

### DIFF
--- a/src/Controller/Backoffice/LarpCharacterSubmissionsController.php
+++ b/src/Controller/Backoffice/LarpCharacterSubmissionsController.php
@@ -4,7 +4,13 @@ namespace App\Controller\Backoffice;
 
 use App\Controller\BaseController;
 use App\Entity\Larp;
+use App\Entity\LarpApplicationChoice;
+use App\Form\Filter\LarpApplicationFilterType;
+use App\Repository\LarpApplicationChoiceRepository;
+use App\Repository\LarpApplicationRepository;
 use App\Service\Larp\SubmissionStatsService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -12,15 +18,76 @@ use Symfony\Component\Routing\Attribute\Route;
 class LarpCharacterSubmissionsController extends BaseController
 {
     #[Route('', name: 'list', methods: ['GET'])]
-    public function list(Larp $larp, SubmissionStatsService $statsService): Response
-    {
+    public function list(
+        Request $request,
+        Larp $larp,
+        LarpApplicationRepository $repository,
+        SubmissionStatsService $statsService
+    ): Response {
+        $filterForm = $this->createForm(LarpApplicationFilterType::class, null, ['larp' => $larp]);
+        $filterForm->handleRequest($request);
+
+        $qb = $repository->createQueryBuilder('a')
+            ->leftJoin('a.choices', 'choice')
+            ->leftJoin('choice.character', 'character')
+            ->leftJoin('character.factions', 'faction')
+            ->addSelect('choice', 'character', 'faction')
+            ->andWhere('a.larp = :larp')
+            ->setParameter('larp', $larp);
+
+        $this->filterBuilderUpdater->addFilterConditions($filterForm, $qb);
+
+        $qb->orderBy('a.createdAt', 'DESC');
+
         $stats = $statsService->getStatsForLarp($larp);
 
         return $this->render('backoffice/larp/application/list.html.twig', [
             'larp' => $larp,
-            'applications' => $stats['applications'],
+            'filterForm' => $filterForm->createView(),
+            'applications' => $qb->getQuery()->getResult(),
             'missing' => $stats['missing'],
             'factionStats' => $stats['factionStats'],
         ]);
+    }
+
+    #[Route('match', name: 'match', methods: ['GET'])]
+    public function match(
+        Larp $larp,
+        EntityManagerInterface $em
+    ): Response {
+        $choiceRepository = $em->getRepository(LarpApplicationChoice::class);
+        $choices = $choiceRepository->createQueryBuilder('c')
+            ->join('c.application', 'a')
+            ->join('c.character', 'ch')
+            ->leftJoin('ch.factions', 'f')
+            ->addSelect('a', 'ch', 'f')
+            ->andWhere('a.larp = :larp')
+            ->setParameter('larp', $larp)
+            ->orderBy('ch.title', 'ASC')
+            ->addOrderBy('c.priority', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $grouped = [];
+        foreach ($choices as $choice) {
+            $id = $choice->getCharacter()->getId()->toRfc4122();
+            $grouped[$id]['character'] = $choice->getCharacter();
+            $grouped[$id]['choices'][] = $choice;
+        }
+
+        return $this->render('backoffice/larp/application/match.html.twig', [
+            'larp' => $larp,
+            'choices' => $grouped,
+        ]);
+    }
+
+    #[Route('vote/{choice}', name: 'vote', methods: ['POST'])]
+    public function vote(Larp $larp, LarpApplicationChoice $choice, EntityManagerInterface $em): Response
+    {
+        $choice->setVotes($choice->getVotes() + 1);
+        $em->flush();
+
+        $this->addFlash('success', 'backoffice.larp.applications.vote_success');
+        return $this->redirectToRoute('backoffice_larp_applications_match', ['larp' => $larp->getId()]);
     }
 }

--- a/src/Controller/Public/LarpCharacterSubmissionController.php
+++ b/src/Controller/Public/LarpCharacterSubmissionController.php
@@ -27,6 +27,11 @@ class LarpCharacterSubmissionController extends BaseController
             throw $this->createAccessDeniedException();
         }
 
+        if ($repository->findOneBy(['larp' => $larp, 'user' => $this->getUser()])) {
+            $this->addFlash('error', 'backoffice.larp.applications.already_submitted');
+            return $this->redirectToRoute('public_larp_details', ['slug' => $larp->getSlug()]);
+        }
+
         $application = new LarpApplication();
         $application->setLarp($larp);
         $application->setUser($this->getUser());

--- a/src/Entity/LarpApplicationChoice.php
+++ b/src/Entity/LarpApplicationChoice.php
@@ -31,6 +31,9 @@ class LarpApplicationChoice
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $visual = null;
 
+    #[ORM\Column(type: 'integer')]
+    private int $votes = 0;
+
     public function getApplication(): LarpApplication
     {
         return $this->application;
@@ -79,5 +82,15 @@ class LarpApplicationChoice
     public function setVisual(?string $visual): void
     {
         $this->visual = $visual;
+    }
+
+    public function getVotes(): int
+    {
+        return $this->votes;
+    }
+
+    public function setVotes(int $votes): void
+    {
+        $this->votes = $votes;
     }
 }

--- a/src/Form/Filter/LarpApplicationFilterType.php
+++ b/src/Form/Filter/LarpApplicationFilterType.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Form\Filter;
+
+use App\Entity\Larp;
+use App\Entity\StoryObject\LarpCharacter;
+use App\Entity\StoryObject\LarpFaction;
+use App\Repository\StoryObject\LarpCharacterRepository;
+use App\Repository\StoryObject\LarpFactionRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LarpApplicationFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Larp $larp */
+        $larp = $options['larp'];
+
+        $builder
+            ->add('character', EntityType::class, [
+                'class' => LarpCharacter::class,
+                'choice_label' => 'title',
+                'required' => false,
+                'autocomplete' => true,
+                'placeholder' => 'form.choose',
+                'data_extraction_method' => 'default',
+                'query_builder' => function (LarpCharacterRepository $repo) use ($larp) {
+                    return $repo->createQueryBuilder('c')
+                        ->where('c.larp = :larp')
+                        ->setParameter('larp', $larp);
+                },
+            ])
+            ->add('faction', EntityType::class, [
+                'class' => LarpFaction::class,
+                'choice_label' => 'title',
+                'required' => false,
+                'autocomplete' => true,
+                'placeholder' => 'form.choose',
+                'data_extraction_method' => 'default',
+                'query_builder' => function (LarpFactionRepository $repo) use ($larp) {
+                    return $repo->createQueryBuilder('f')
+                        ->where('f.larp = :larp')
+                        ->setParameter('larp', $larp);
+                },
+            ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'larp_application_filter';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'validation_groups' => ['filtering'],
+            'method' => 'GET',
+            'translation_domain' => 'forms',
+            'larp' => null,
+        ]);
+
+        $resolver->setRequired('larp');
+        $resolver->setAllowedTypes('larp', Larp::class);
+    }
+}

--- a/templates/backoffice/larp/application/list.html.twig
+++ b/templates/backoffice/larp/application/list.html.twig
@@ -3,6 +3,7 @@
 {% block larp_content %}
     <h2>{{ 'backoffice.larp.applications.title'|trans }}</h2>
     <p>{{ 'backoffice.larp.applications.missing'|trans({'%count%': missing}) }}</p>
+    {% include 'includes/filter_form.html.twig' with { form: filterForm, larp: larp } %}
     <ul>
         {% for stat in factionStats %}
             <li>{{ stat.faction.title }} - {{ stat.percentage }}%</li>

--- a/templates/backoffice/larp/application/match.html.twig
+++ b/templates/backoffice/larp/application/match.html.twig
@@ -1,0 +1,38 @@
+{% extends 'backoffice/larp/base.html.twig' %}
+
+{% block larp_content %}
+    <h2>{{ 'backoffice.larp.applications.match'|trans }}</h2>
+    {% for data in choices %}
+        <h3>{{ data.character.title }}</h3>
+        <table class="table">
+            <thead>
+            <tr>
+                <th>{{ 'common.user'|trans }}</th>
+                <th>{{ 'form.priority'|trans }}</th>
+                <th>{{ 'form.justification'|trans }}</th>
+                <th>{{ 'form.visual'|trans }}</th>
+                <th>{{ 'common.votes'|trans }}</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for choice in data.choices %}
+                <tr>
+                    <td>{{ choice.application.user.username }}</td>
+                    <td>{{ choice.priority }}</td>
+                    <td>{{ choice.justification|default('-') }}</td>
+                    <td>{{ choice.visual|default('-') }}</td>
+                    <td>{{ choice.votes }}</td>
+                    <td>
+                        <form method="post" action="{{ path('backoffice_larp_applications_vote', {larp: larp.id, choice: choice.id}) }}">
+                            <button class="btn btn-sm btn-primary" type="submit">+</button>
+                        </form>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>{{ 'common.empty_list'|trans }}</p>
+    {% endfor %}
+{% endblock %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -122,6 +122,9 @@ backoffice:
     applications:
       title: 'Character Applications'
       missing: 'Characters without applications: %count%'
+      already_submitted: 'You have already submitted an application.'
+      match: 'Application Matching'
+      vote_success: 'Vote recorded'
     relation:
       list: 'Relations'
       add: 'Add Relation'
@@ -143,6 +146,7 @@ backoffice:
     success_save: "Successfully saved changes"
     success_delete: "Successfully removed"
     confirmation: "Are you sure you want to proceed? This action cannot be undone."
+    votes: "Votes"
   recruitment:
     open: "Open recruitments"
     none: "No recruitments"


### PR DESCRIPTION
## Summary
- ensure single application per user
- allow filtering LARP applications
- support voting on character choices
- show matching view for story writers
- add translation strings

## Testing
- `composer run-script ecs`
- `composer run-script phpstan`
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_6851bed7433c8326820f918fbb5a00f1