### PR TITLE
Implement optional character choices in applications

### DIFF
--- a/src/Controller/Public/LarpCharacterSubmissionController.php
+++ b/src/Controller/Public/LarpCharacterSubmissionController.php
@@ -46,6 +46,12 @@ class LarpCharacterSubmissionController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            foreach ($application->getChoices()->toArray() as $choice) {
+                if (null === $choice->getCharacter()) {
+                    $application->removeChoice($choice);
+                }
+            }
+
             $repository->save($application);
             $this->addFlash('success', 'Application created');
             return $this->redirectToRoute('public_larp_details', ['slug' => $larp->getSlug()]);

--- a/src/Form/LarpCharacterSubmissionChoiceType.php
+++ b/src/Form/LarpCharacterSubmissionChoiceType.php
@@ -29,6 +29,7 @@ class LarpCharacterSubmissionChoiceType extends AbstractType
                 'label' => 'form.character.name',
                 'placeholder' => 'form.choose',
                 'autocomplete' => true,
+                'required' => false,
             ])
             ->add('priority', IntegerType::class, [
                 'label' => 'form.priority',


### PR DESCRIPTION
## Summary
- allow character field in application choice to be optional
- drop empty choices before persisting

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`


------
https://chatgpt.com/codex/tasks/task_e_6852724e13e08326b82893936384fe95