### PR TITLE
Add StoryObject mention search and WYSIWYG editor

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2,3 +2,4 @@ import './bootstrap.js';
 
 import './styles/app.css';
 import './styles/folder_browser.css';
+import './styles/wysiwyg.css';

--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -6,6 +6,7 @@ import GoogleFilePickerController from "./controllers/integrations/google_file_p
 import CustomAutocompleteController from "./controllers/custom-autocomplete_controller.js";
 import StoryGraphController from "./controllers/story_graph_controller.js";
 import DecisionTreeController from "./controllers/decision_tree_controller.js";
+import WysiwygController from "./controllers/wysiwyg_controller.js";
 
 const app = startStimulusApp();
 app.register('live', LiveController);
@@ -14,3 +15,4 @@ app.register("google-file-picker", GoogleFilePickerController);
 app.register("custom-autocomplete", CustomAutocompleteController);
 app.register("story-graph", StoryGraphController);
 app.register("decision-tree", DecisionTreeController);
+app.register("wysiwyg", WysiwygController);

--- a/assets/controllers/wysiwyg_controller.js
+++ b/assets/controllers/wysiwyg_controller.js
@@ -1,0 +1,99 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = {
+        larp: String,
+        searchUrl: { type: String, default: '/backoffice/larp/__larp__/story-object/mention-search' },
+    };
+
+    connect() {
+        this.textarea = this.element;
+        if (!this.hasLarpValue) {
+            const match = window.location.pathname.match(/\/larp\/([^/]+)/);
+            if (match) {
+                this.larpValue = match[1];
+            }
+        }
+        this.searchUrl = this.searchUrlValue.replace('__larp__', this.larpValue);
+        this.editor = document.createElement('div');
+        this.editor.classList.add('wysiwyg-editor');
+        this.editor.contentEditable = true;
+        this.editor.innerHTML = this.textarea.value;
+        this.textarea.style.display = 'none';
+        this.textarea.parentNode.insertBefore(this.editor, this.textarea);
+        this._createDropdown();
+        this.editor.addEventListener('keyup', (e) => this._onKeyUp(e));
+        this.textarea.form?.addEventListener('submit', () => this._onSubmit());
+    }
+
+    disconnect() {
+        this.editor.removeEventListener('keyup', (e) => this._onKeyUp(e));
+        this.textarea.form?.removeEventListener('submit', () => this._onSubmit());
+        this.textarea.style.display = '';
+        this._onSubmit();
+        this.dropdown.remove();
+    }
+
+    _createDropdown() {
+        this.dropdown = document.createElement('div');
+        this.dropdown.classList.add('mention-dropdown');
+        this.dropdown.style.display = 'none';
+        document.body.appendChild(this.dropdown);
+    }
+
+    _onKeyUp(event) {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) {
+            return;
+        }
+        if (!this.larpValue) {
+            return;
+        }
+        const range = sel.getRangeAt(0);
+        const prefix = range.startContainer.textContent?.slice(0, range.startOffset) || '';
+        const match = prefix.match(/@([\w\s]{2,})$/);
+        if (!match) {
+            this.dropdown.style.display = 'none';
+            return;
+        }
+        const query = match[1];
+        fetch(`${this.searchUrl}?query=${encodeURIComponent(query)}`)
+            .then(r => r.json())
+            .then(list => {
+                this.dropdown.innerHTML = '';
+                list.forEach(item => {
+                    const div = document.createElement('div');
+                    div.textContent = item.name;
+                    div.addEventListener('mousedown', e => {
+                        e.preventDefault();
+                        this._insertMention(item);
+                    });
+                    this.dropdown.appendChild(div);
+                });
+                const rect = range.getBoundingClientRect();
+                this.dropdown.style.top = `${rect.bottom + window.scrollY}px`;
+                this.dropdown.style.left = `${rect.left + window.scrollX}px`;
+                this.dropdown.style.display = 'block';
+            });
+    }
+
+    _insertMention(item) {
+        const span = document.createElement('span');
+        span.dataset.storyObjectId = item.id;
+        span.textContent = '@' + item.name;
+        span.contentEditable = 'false';
+        const sel = window.getSelection();
+        const range = sel.getRangeAt(0);
+        range.deleteContents();
+        range.insertNode(span);
+        range.setStartAfter(span);
+        range.setEndAfter(span);
+        sel.removeAllRanges();
+        sel.addRange(range);
+        this.dropdown.style.display = 'none';
+    }
+
+    _onSubmit() {
+        this.textarea.value = this.editor.innerHTML;
+    }
+}

--- a/assets/styles/wysiwyg.css
+++ b/assets/styles/wysiwyg.css
@@ -1,0 +1,21 @@
+.wysiwyg-editor {
+    min-height: 150px;
+    border: 1px solid #ced4da;
+    padding: 0.5rem;
+}
+
+.mention-dropdown {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #ccc;
+    z-index: 1000;
+}
+
+.mention-dropdown div {
+    padding: 2px 4px;
+    cursor: pointer;
+}
+
+.mention-dropdown div:hover {
+    background: #e9ecef;
+}

--- a/importmap.php
+++ b/importmap.php
@@ -47,4 +47,7 @@ return [
     'decision-tree-controller' => [
         'path' => './assets/controllers/decision_tree_controller.js',
     ],
+    'wysiwyg-controller' => [
+        'path' => './assets/controllers/wysiwyg_controller.js',
+    ],
 ];

--- a/src/Controller/API/StoryObjectMentionController.php
+++ b/src/Controller/API/StoryObjectMentionController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\Larp;
+use App\Repository\StoryObject\StoryObjectRepository;
+use App\Security\Voter\Backoffice\Larp\LarpStoryVoter;
+use App\Service\StoryObject\StoryObjectRouter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+class StoryObjectMentionController extends AbstractController
+{
+    #[Route('/larp/{larp}/story-object/mention-search', name: 'backoffice_story_object_mention_search', methods: ['GET'])]
+    public function __invoke(
+        Request $request,
+        Larp $larp,
+        StoryObjectRepository $repository,
+        StoryObjectRouter $router,
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(LarpStoryVoter::VIEW, $larp);
+        $query = $request->query->get('query', '');
+
+        $objects = $repository->searchByTitle($larp, $query);
+        $result = [];
+        foreach ($objects as $object) {
+            $result[] = [
+                'id' => $object->getId()->toRfc4122(),
+                'name' => $object->getTitle(),
+                'type' => $object::getTargetType()->value,
+                'url' => $router->getEditUrl($object, $larp),
+            ];
+        }
+        return new JsonResponse($result);
+    }
+}

--- a/src/Controller/Backoffice/Story/ThreadController.php
+++ b/src/Controller/Backoffice/Story/ThreadController.php
@@ -54,6 +54,7 @@ class ThreadController extends BaseController
         Request            $request,
         Larp               $larp,
         ThreadRepository   $threadRepository,
+        \App\Service\StoryObject\StoryObjectTextLinker $textLinker,
         ?Thread            $thread = null,
     ): Response {
         $new = false;
@@ -67,6 +68,9 @@ class ThreadController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $thread->setDescription(
+                $textLinker->finalizeMentions((string) $thread->getDescription(), $larp)
+            );
             $threadRepository->save($thread);
 
             $this->processIntegrationsForStoryObject($larpManager, $larp, $integrationManager, $new, $thread);

--- a/src/Form/ThreadType.php
+++ b/src/Form/ThreadType.php
@@ -31,6 +31,9 @@ class ThreadType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.thread.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('involvedFactions', EntityType::class, [
                 'class' => LarpFaction::class,

--- a/src/Repository/StoryObject/StoryObjectRepository.php
+++ b/src/Repository/StoryObject/StoryObjectRepository.php
@@ -32,6 +32,21 @@ class StoryObjectRepository extends BaseRepository
     }
 
     /**
+     * @return StoryObject[]
+     */
+    public function searchByTitle(Larp $larp, string $query, int $limit = 10): array
+    {
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.larp = :larp')
+            ->andWhere('LOWER(o.title) LIKE :q')
+            ->setParameter('larp', $larp)
+            ->setParameter('q', '%' . strtolower($query) . '%')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * @param Larp                $larp
      * @param Collection<int, Thread>|Thread[]       $threads
      * @param Collection<int, LarpCharacter>|LarpCharacter[] $characters

--- a/src/Service/StoryObject/StoryObjectRouter.php
+++ b/src/Service/StoryObject/StoryObjectRouter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Service\StoryObject;
+
+use App\Entity\Enum\TargetType;
+use App\Entity\Larp;
+use App\Entity\StoryObject\StoryObject;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class StoryObjectRouter
+{
+    private const ROUTE_MAP = [
+        TargetType::Character->value => ['backoffice_larp_story_character_modify', 'character'],
+        TargetType::Faction->value => ['backoffice_larp_story_faction_modify', 'faction'],
+        TargetType::Thread->value => ['backoffice_larp_story_thread_modify', 'thread'],
+        TargetType::Event->value => ['backoffice_larp_story_event_modify', 'event'],
+        TargetType::Quest->value => ['backoffice_larp_story_quest_modify', 'quest'],
+        TargetType::Item->value => ['backoffice_larp_story_item_modify', 'item'],
+        TargetType::Place->value => ['backoffice_larp_story_place_modify', 'place'],
+    ];
+
+    public function __construct(private UrlGeneratorInterface $urlGenerator)
+    {
+    }
+
+    public function getEditUrl(StoryObject $object, Larp $larp): ?string
+    {
+        $type = $object::getTargetType()->value;
+        if (!isset(self::ROUTE_MAP[$type])) {
+            return null;
+        }
+        [$route, $param] = self::ROUTE_MAP[$type];
+
+        return $this->urlGenerator->generate($route, [
+            'larp' => $larp->getId(),
+            $param => $object->getId(),
+        ]);
+    }
+}

--- a/src/Service/StoryObject/StoryObjectTextLinker.php
+++ b/src/Service/StoryObject/StoryObjectTextLinker.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Service\StoryObject;
+
+use App\Entity\Larp;
+use App\Repository\StoryObject\StoryObjectRepository;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class StoryObjectTextLinker
+{
+    public function __construct(
+        private StoryObjectRepository $storyObjectRepository,
+        private StoryObjectRouter $router,
+    ) {
+    }
+
+    public function finalizeMentions(string $html, Larp $larp): string
+    {
+        if ($html === '') {
+            return $html;
+        }
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        @$dom->loadHTML('<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $xpath = new \DOMXPath($dom);
+        foreach ($xpath->query('//*[@data-story-object-id]') as $node) {
+            $id = $node->getAttribute('data-story-object-id');
+            $object = $this->storyObjectRepository->find(Uuid::fromString($id));
+            if (!$object || $object->getLarp()?->getId()->toRfc4122() !== $larp->getId()->toRfc4122()) {
+                continue;
+            }
+            $href = $this->router->getEditUrl($object, $larp);
+            if (!$href) {
+                continue;
+            }
+            $link = $dom->createElement('a');
+            $link->setAttribute('href', $href);
+            $link->nodeValue = $node->textContent;
+            $node->parentNode->replaceChild($link, $node);
+        }
+        return $dom->saveHTML();
+    }
+}


### PR DESCRIPTION
## Summary
- implement a basic contenteditable WYSIWYG Stimulus controller with mention dropdown
- add style rules for editor and dropdown
- register controller and import CSS/JS in importmap and bootstrap
- create API endpoint `/api/story-object/mention-search` returning matching objects
- add method to StoryObjectRepository to search by title
- link thread descriptions on save using new `StoryObjectTextLinker`
- enable editor on thread description field
- secure mention search endpoint, auto-detect LARP id on editor, generate proper backoffice links
- adjust mention search endpoint path

## Testing
- `composer exec -- "vendor/bin/phpunit -c phpunit.xml.dist"`
- `composer exec -- "vendor/bin/ecs check"`
- `composer exec -- "vendor/bin/phpstan analyse -c phpstan.neon"`


------
https://chatgpt.com/codex/tasks/task_e_6851b3f408a48326b4b708bc4a6f9997