### PR TITLE
Implement basic story object versioning

### DIFF
--- a/migrations/Version20250616180000.php
+++ b/migrations/Version20250616180000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250616180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add log table for story objects';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE story_object_log_entry (id INT NOT NULL, action VARCHAR(8) NOT NULL, logged_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, object_id VARCHAR(64) DEFAULT NULL, object_class VARCHAR(191) NOT NULL, version INT NOT NULL, data JSON DEFAULT NULL, username VARCHAR(191) DEFAULT NULL, PRIMARY KEY(id))");
+        $this->addSql("CREATE INDEX story_object_class_lookup_idx ON story_object_log_entry (object_class)");
+        $this->addSql("CREATE INDEX story_object_date_lookup_idx ON story_object_log_entry (logged_at)");
+        $this->addSql("CREATE INDEX story_object_user_lookup_idx ON story_object_log_entry (username)");
+        $this->addSql("CREATE INDEX story_object_version_lookup_idx ON story_object_log_entry (object_id, object_class, version)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE story_object_log_entry');
+    }
+}

--- a/src/Entity/StoryObject/Event.php
+++ b/src/Entity/StoryObject/Event.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 #[ORM\Entity(repositoryClass: EventRepository::class)]
 class Event extends StoryObject
@@ -41,6 +42,7 @@ class Event extends StoryObject
     #[ORM\JoinColumn(nullable: true)]
     private ?Place $place = null;
 
+    #[Gedmo\Versioned]
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $storyMoment = null;
 
@@ -50,9 +52,11 @@ class Event extends StoryObject
     #[ORM\Column(length: 20, nullable: true, enumType: StoryTimeUnit::class)]
     private ?StoryTimeUnit $storyTimeUnit = null;
 
+    #[Gedmo\Versioned]
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $startTime = null;
 
+    #[Gedmo\Versioned]
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $endTime = null;
 

--- a/src/Entity/StoryObject/LarpCharacter.php
+++ b/src/Entity/StoryObject/LarpCharacter.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
-#[Gedmo\Loggable]
 #[UniqueEntity(
     fields: ['larp', 'title'],
     message: 'A character with this title already exists in this LARP.'
@@ -25,6 +24,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 #[ORM\Entity(repositoryClass: LarpCharacterRepository::class)]
 class LarpCharacter extends StoryObject
 {
+    #[Gedmo\Versioned]
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $inGameName = null;
 
@@ -41,6 +41,7 @@ class LarpCharacter extends StoryObject
     #[ORM\Column(type: "text", nullable: true)]
     private ?string $postLarpFate = null;
     
+    #[Gedmo\Versioned]
     #[ORM\Column(length: 255, nullable: true, enumType: Gender::class)]
     private ?Gender $gender = null;
 

--- a/src/Entity/StoryObject/StoryObject.php
+++ b/src/Entity/StoryObject/StoryObject.php
@@ -5,6 +5,7 @@ namespace App\Entity\StoryObject;
 use App\Entity\Enum\TargetType;
 use App\Entity\ExternalReference;
 use App\Entity\Larp;
+use App\Entity\StoryObjectLogEntry;
 use App\Entity\TargetableInterface;
 use App\Entity\Trait\CreatorAwareInterface;
 use App\Entity\Trait\CreatorAwareTrait;
@@ -14,6 +15,7 @@ use App\Repository\StoryObject\StoryObjectRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Timestampable;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\Uid\Uuid;
@@ -33,6 +35,7 @@ use Symfony\Component\Uid\Uuid;
     TargetType::Item->value => Item::class,
     TargetType::Place->value => Place::class,
 ])]
+#[Gedmo\Loggable(logEntryClass: StoryObjectLogEntry::class)]
 abstract class StoryObject implements CreatorAwareInterface, Timestampable, TargetableInterface, LarpAwareInterface
 {
     use UuidTraitEntity;
@@ -44,12 +47,15 @@ abstract class StoryObject implements CreatorAwareInterface, Timestampable, Targ
     * It should be unique within the context of the LARP - title of the vacancy, thread, quest name, etc.
     *
     */
+    #[Gedmo\Versioned]
     #[ORM\Column(length: 255)]
     protected ?string $title = null;
 
+    #[Gedmo\Versioned]
     #[ORM\Column(type: 'text', nullable: true)]
     protected ?string $description = null;
 
+    #[Gedmo\Versioned]
     #[ORM\ManyToOne(targetEntity: Larp::class)]
     #[ORM\JoinColumn(nullable: false)]
     protected ?Larp $larp = null;

--- a/src/Entity/StoryObjectLogEntry.php
+++ b/src/Entity/StoryObjectLogEntry.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry;
+use Gedmo\Loggable\Entity\Repository\LogEntryRepository;
+use Gedmo\Loggable\Loggable;
+
+#[ORM\Entity(repositoryClass: LogEntryRepository::class)]
+#[ORM\Table(name: 'story_object_log_entry')]
+#[ORM\Index(name: 'story_object_class_lookup_idx', columns: ['object_class'])]
+#[ORM\Index(name: 'story_object_date_lookup_idx', columns: ['logged_at'])]
+#[ORM\Index(name: 'story_object_user_lookup_idx', columns: ['username'])]
+#[ORM\Index(name: 'story_object_version_lookup_idx', columns: ['object_id', 'object_class', 'version'])]
+class StoryObjectLogEntry extends AbstractLogEntry
+{
+    /*
+     * All required columns are mapped through inherited superclass
+     */
+}

--- a/src/Service/StoryObject/StoryObjectVersionService.php
+++ b/src/Service/StoryObject/StoryObjectVersionService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Service\StoryObject;
+
+use App\Entity\StoryObject\StoryObject;
+use App\Entity\StoryObjectLogEntry;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class StoryObjectVersionService
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return array<int, array{entry: StoryObjectLogEntry, diff: array<string, mixed>}>
+     */
+    public function getVersionHistory(StoryObject $object): array
+    {
+        /** @var \Gedmo\Loggable\Entity\Repository\LogEntryRepository $repo */
+        $repo = $this->em->getRepository(StoryObjectLogEntry::class);
+        $entries = $repo->getLogEntries($object);
+
+        $history = [];
+        $previousData = null;
+        foreach (array_reverse($entries) as $entry) {
+            $data = $entry->getData() ?? [];
+            $diff = [];
+            if ($previousData !== null) {
+                foreach ($data as $field => $value) {
+                    $old = $previousData[$field] ?? null;
+                    if ($old !== $value) {
+                        $diff[$field] = ['old' => $old, 'new' => $value];
+                    }
+                }
+            }
+            $history[] = ['entry' => $entry, 'diff' => $diff];
+            $previousData = $data;
+        }
+
+        return array_reverse($history);
+    }
+}

--- a/src/Twig/Components/StoryObjectVersionHistory.php
+++ b/src/Twig/Components/StoryObjectVersionHistory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Twig\Components;
+
+use App\Entity\StoryObject\StoryObject;
+use App\Service\StoryObject\StoryObjectVersionService;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent]
+class StoryObjectVersionHistory
+{
+    use DefaultActionTrait;
+
+    public function __construct(private readonly StoryObjectVersionService $service)
+    {
+    }
+
+    #[LiveProp]
+    public StoryObject $storyObject;
+
+    public function getHistory(): array
+    {
+        return $this->service->getVersionHistory($this->storyObject);
+    }
+}

--- a/templates/backoffice/larp/characters/modify.html.twig
+++ b/templates/backoffice/larp/characters/modify.html.twig
@@ -127,6 +127,13 @@
             </div>
         </div>
     </div>
+    <div class="card mb-3 shadow-sm">
+        <div class="card-header">Version history</div>
+        <div class="card-body">
+            {{ component('StoryObjectVersionHistory', { storyObject: character }) }}
+        </div>
+    </div>
+
 {% endblock %}
 
 {% block title %}{{ larp.name }} - {{ character.getTitle() ?? 'common.new'|trans }}{% endblock %}

--- a/templates/components/StoryObjectVersionHistory.html.twig
+++ b/templates/components/StoryObjectVersionHistory.html.twig
@@ -1,0 +1,15 @@
+{# templates/components/StoryObjectVersionHistory.html.twig #}
+<div {{ attributes }}>
+    <ul class="list-unstyled">
+        {% for item in this.getHistory() %}
+            <li class="mb-3">
+                <strong>{{ item.entry.loggedAt|date('Y-m-d H:i') }} - {{ item.entry.username }}</strong>
+                <ul>
+                    {% for field, change in item.diff %}
+                        <li>{{ field }}: {{ change.old }} -> {{ change.new }}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/tests/Service/StoryObjectVersionServiceTest.php
+++ b/tests/Service/StoryObjectVersionServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\StoryObject\LarpCharacter;
+use App\Entity\StoryObjectLogEntry;
+use App\Service\StoryObject\StoryObjectVersionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Gedmo\Loggable\Entity\Repository\LogEntryRepository;
+use PHPUnit\Framework\TestCase;
+
+class StoryObjectVersionServiceTest extends TestCase
+{
+    public function testVersionHistoryDiff(): void
+    {
+        $character = new LarpCharacter();
+
+        $e1 = new StoryObjectLogEntry();
+        $ref = new \ReflectionClass($e1);
+        $dataProp = $ref->getProperty('data');
+        $dataProp->setAccessible(true);
+        $dataProp->setValue($e1, ['title' => 'Hero']);
+
+        $e2 = new StoryObjectLogEntry();
+        $dataProp->setValue($e2, ['title' => 'Hero Updated']);
+
+        $repo = $this->createMock(LogEntryRepository::class);
+        $repo->expects($this->once())->method('getLogEntries')->with($character)->willReturn([$e2, $e1]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->with(StoryObjectLogEntry::class)->willReturn($repo);
+
+        $service = new StoryObjectVersionService($em);
+        $history = $service->getVersionHistory($character);
+
+        $this->assertCount(2, $history);
+        $this->assertSame('Hero Updated', $history[0]['entry']->getData()['title']);
+        $this->assertSame('Hero', $history[1]['entry']->getData()['title']);
+        $this->assertSame(['old' => 'Hero', 'new' => 'Hero Updated'], $history[0]['diff']['title']);
+    }
+}


### PR DESCRIPTION
## Summary
- enable Gedmo loggable on StoryObject base class
- add versioned fields on story objects and events
- introduce StoryObjectLogEntry entity and version service
- expose version history through a LiveComponent
- display version history on character form
- add migration and a unit test for version diffs

## Testing
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_685312abcd508326b314f9b12c6e8c96