### PR TITLE
Add forms for document mappings

### DIFF
--- a/src/Entity/Enum/ResourceType.php
+++ b/src/Entity/Enum/ResourceType.php
@@ -3,8 +3,10 @@
 namespace App\Entity\Enum;
 
 use App\Form\Integrations\CharacterDocDirectoryMappingType;
+use App\Form\Integrations\CharacterDocMappingType;
 use App\Form\Integrations\CharacterListColumnMappingType;
 use App\Form\Integrations\DocumentMetaFormType;
+use App\Form\Integrations\EventDocMappingType;
 use App\Form\Integrations\EventListColumnMappingType;
 use App\Form\Integrations\SpreadsheetMetaFormType;
 use Symfony\Component\Form\AbstractType;
@@ -26,8 +28,8 @@ enum ResourceType: string
             self::CHARACTER_LIST => CharacterListColumnMappingType::class,
             self::EVENT_LIST => EventListColumnMappingType::class,
             self::CHARACTER_DOC_DIRECTORY => CharacterDocDirectoryMappingType::class,
-            self::CHARACTER_DOC => throw new \Exception('To be implemented'),
-            self::EVENT_DOC => throw new \Exception('To be implemented'),
+            self::CHARACTER_DOC => CharacterDocMappingType::class,
+            self::EVENT_DOC => EventDocMappingType::class,
         };
     }
 
@@ -38,7 +40,7 @@ enum ResourceType: string
     {
         return match ($this) {
             self::CHARACTER_LIST, self::EVENT_LIST => SpreadsheetMetaFormType::class,
-            self::CHARACTER_DOC => DocumentMetaFormType::class,
+            self::CHARACTER_DOC, self::EVENT_DOC => DocumentMetaFormType::class,
             default => null,
             // etc.
         };

--- a/src/Form/Integrations/CharacterDocMappingType.php
+++ b/src/Form/Integrations/CharacterDocMappingType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Form\Integrations;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CharacterDocMappingType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'form.character.name',
+            ])
+            ->add('description', TextType::class, [
+                'label' => 'form.character.description',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/Form/Integrations/EventDocMappingType.php
+++ b/src/Form/Integrations/EventDocMappingType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Form\Integrations;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EventDocMappingType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('eventName', TextType::class, [
+                'label' => 'form.event.name',
+            ])
+            ->add('description', TextType::class, [
+                'label' => 'form.event.description',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/tests/Form/FileMappingTypeTest.php
+++ b/tests/Form/FileMappingTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Form;
+
+use App\Entity\Enum\ResourceType;
+use App\Form\Integrations\FileMappingType;
+use App\Form\Models\ExternalResourceMappingModel;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class FileMappingTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        return [new PreloadedExtension([], [])];
+    }
+
+    public function testCharacterDocSubFormAppears(): void
+    {
+        $model = new ExternalResourceMappingModel(ResourceType::CHARACTER_DOC);
+        $form = $this->factory->create(FileMappingType::class, $model, [
+            'mimeType' => 'application/vnd.google-apps.document',
+        ]);
+
+        $this->assertTrue($form->get('mappings')->has('title'));
+        $this->assertTrue($form->get('mappings')->has('description'));
+    }
+
+    public function testEventDocSubFormAppears(): void
+    {
+        $model = new ExternalResourceMappingModel(ResourceType::EVENT_DOC);
+        $form = $this->factory->create(FileMappingType::class, $model, [
+            'mimeType' => 'application/vnd.google-apps.document',
+        ]);
+
+        $this->assertTrue($form->get('mappings')->has('eventName'));
+        $this->assertTrue($form->get('mappings')->has('description'));
+    }
+
+    public function testAllowedTypesForDocument(): void
+    {
+        $type = new FileMappingType();
+        $allowed = $type->getAllowedResourceTypes('application/vnd.google-apps.document');
+        $this->assertContains(ResourceType::CHARACTER_DOC, $allowed);
+        $this->assertContains(ResourceType::EVENT_DOC, $allowed);
+    }
+
+    public function testSubFormMappingTypes(): void
+    {
+        $this->assertSame(
+            \App\Form\Integrations\CharacterDocMappingType::class,
+            ResourceType::CHARACTER_DOC->getSubForm()
+        );
+        $this->assertSame(
+            \App\Form\Integrations\EventDocMappingType::class,
+            ResourceType::EVENT_DOC->getSubForm()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `CharacterDocMappingType` and `EventDocMappingType`
- support new forms in `ResourceType`
- expose document forms through `FileMappingType`
- test new document mapping forms

## Testing
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/ecs check`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_68570047a9488326ae8f50a1125a2831