### PR TITLE
Ensure graph filtering loads faction relations

### DIFF
--- a/src/Repository/StoryObject/StoryObjectRepository.php
+++ b/src/Repository/StoryObject/StoryObjectRepository.php
@@ -110,6 +110,19 @@ class StoryObjectRepository extends BaseRepository
                     'SELECT e.id FROM ' . Event::class . ' e JOIN e.involvedFactions f WHERE e.larp = :larp AND f.id = :f',
                     ['larp' => $larp, 'f' => $fid]
                 ));
+                // include objects linked through faction members
+                $ids = array_merge($ids, $this->fetchIds(
+                    'SELECT t.id FROM ' . Thread::class . ' t JOIN t.involvedCharacters c JOIN c.factions f WHERE t.larp = :larp AND f.id = :f',
+                    ['larp' => $larp, 'f' => $fid]
+                ));
+                $ids = array_merge($ids, $this->fetchIds(
+                    'SELECT q.id FROM ' . Quest::class . ' q JOIN q.involvedCharacters c JOIN c.factions f WHERE q.larp = :larp AND f.id = :f',
+                    ['larp' => $larp, 'f' => $fid]
+                ));
+                $ids = array_merge($ids, $this->fetchIds(
+                    'SELECT e2.id FROM ' . Event::class . ' e2 JOIN e2.involvedCharacters c JOIN c.factions f WHERE e2.larp = :larp AND f.id = :f',
+                    ['larp' => $larp, 'f' => $fid]
+                ));
                 $factionSets[] = array_unique($ids);
             }
             $sets[] = $this->intersectSets($factionSets);

--- a/tests/Service/StoryGraphFactionFilterTest.php
+++ b/tests/Service/StoryGraphFactionFilterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\StoryObject\LarpCharacter;
+use App\Entity\StoryObject\LarpFaction;
+use App\Entity\StoryObject\Quest;
+use App\Entity\StoryObject\Thread;
+use App\Service\Larp\StoryObjectRelationExplorer;
+use PHPUnit\Framework\TestCase;
+use ShipMonk\DoctrineEntityPreloader\EntityPreloader;
+
+class StoryGraphFactionFilterTest extends TestCase
+{
+    public function testFactionFilterIncludesConnectedNodes(): void
+    {
+        $faction = new LarpFaction();
+        $character = new LarpCharacter();
+        $thread = new Thread();
+        $quest = new Quest();
+
+        $faction->addMember($character);
+        $character->addFaction($faction);
+
+        $thread->addInvolvedCharacter($character);
+        $character->addThread($thread);
+
+        $quest->setThread($thread);
+        $thread->getQuests()->add($quest);
+        $quest->addInvolvedCharacter($character);
+        $character->addQuest($quest);
+
+        $preloader = $this->createMock(EntityPreloader::class);
+        $preloader->method('preload')->willReturn([]);
+
+        $explorer = new StoryObjectRelationExplorer($preloader);
+        $graph = $explorer->getGraphFromResults([
+            $faction,
+            $character,
+            $thread,
+            $quest,
+        ]);
+
+        $nodeIds = array_map(static fn ($n) => $n['data']['id'], $graph['nodes']);
+
+        $this->assertContains($faction->getId()->toRfc4122(), $nodeIds);
+        $this->assertContains($character->getId()->toRfc4122(), $nodeIds);
+        $this->assertContains($thread->getId()->toRfc4122(), $nodeIds);
+        $this->assertContains($quest->getId()->toRfc4122(), $nodeIds);
+    }
+}


### PR DESCRIPTION
## Summary
- preload faction-related objects when filtering by faction
- verify graph explorer includes nodes for faction filters

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist --stop-on-failure`
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`


------
https://chatgpt.com/codex/tasks/task_e_68570007aba88326868366ee510a6326