### PR TITLE
Fix SubmissionStatsService preloader usage

### DIFF
--- a/src/Service/Larp/SubmissionStatsService.php
+++ b/src/Service/Larp/SubmissionStatsService.php
@@ -20,7 +20,7 @@ readonly class SubmissionStatsService
         $applications = $this->repository->findBy(['larp' => $larp]);
         $this->preloader->preload($applications, 'choices');
         $this->preloader->preload($applications, 'choices.character');
-        $this->preloader->preload($larp->getFactions(), 'members');
+        $this->preloader->preload($larp->getFactions()->toArray(), 'members');
 
         $charactersWithApplication = [];
         foreach ($applications as $application) {

--- a/tests/Service/SubmissionStatsServiceTest.php
+++ b/tests/Service/SubmissionStatsServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Larp;
+use App\Entity\LarpApplication;
+use App\Entity\LarpApplicationChoice;
+use App\Entity\StoryObject\LarpCharacter;
+use App\Entity\StoryObject\LarpFaction;
+use App\Repository\LarpApplicationRepository;
+use App\Service\Larp\SubmissionStatsService;
+use PHPUnit\Framework\TestCase;
+use ShipMonk\DoctrineEntityPreloader\EntityPreloader;
+
+class SubmissionStatsServiceTest extends TestCase
+{
+    public function testGetStatsForLarp(): void
+    {
+        $larp = new Larp();
+
+        $faction = new LarpFaction();
+        $larp->addFaction($faction);
+
+        $character = new LarpCharacter();
+        $larp->addCharacter($character);
+        $faction->addMember($character);
+
+        $application = new LarpApplication();
+        $application->setLarp($larp);
+        $choice = new LarpApplicationChoice();
+        $choice->setCharacter($character);
+        $application->addChoice($choice);
+
+        $repo = $this->createMock(LarpApplicationRepository::class);
+        $repo->expects($this->once())
+            ->method('findBy')
+            ->with(['larp' => $larp])
+            ->willReturn([$application]);
+
+        $factionsArray = $larp->getFactions()->toArray();
+
+        $preloader = $this->createMock(EntityPreloader::class);
+        $preloader->expects($this->exactly(3))
+            ->method('preload')
+            ->withConsecutive(
+                [$this->identicalTo([$application]), 'choices'],
+                [$this->identicalTo([$application]), 'choices.character'],
+                [$this->identicalTo($factionsArray), 'members'],
+            );
+
+        $service = new SubmissionStatsService($repo, $preloader);
+        $stats = $service->getStatsForLarp($larp);
+
+        $this->assertSame([$application], $stats['applications']);
+        $this->assertSame(0, $stats['missing']);
+        $this->assertCount(1, $stats['factionStats']);
+        $this->assertSame($faction, $stats['factionStats'][0]['faction']);
+        $this->assertSame(100.0, $stats['factionStats'][0]['percentage']);
+    }
+}


### PR DESCRIPTION
## Summary
- fix passing Doctrine collection to EntityPreloader
- cover SubmissionStatsService with unit test

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/ecs check`
- `vendor/bin/phpstan analyse -c phpstan.neon`


------
https://chatgpt.com/codex/tasks/task_e_685a8573d4808326835ee30e1a387c5c