### PR TITLE
Enable WYSIWYG editor for all description fields

### DIFF
--- a/assets/controllers/wysiwyg_controller.js
+++ b/assets/controllers/wysiwyg_controller.js
@@ -17,19 +17,22 @@ export default class extends Controller {
         this.searchCache = new Map(); // Cache search results
         
             // Check if the CSRF token is available in the page
-            this.csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+        this.csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
 
-            // Get the LARP ID from the data attribute or from the URL
-            if (!this.hasLarpValue) {
-                const match = window.location.pathname.match(/\/larp\/([^/]+)/);
-                if (match) {
-                    this.larpValue = match[1];
-                } else {
-                    console.error('WYSIWYG Editor: No LARP ID provided');
-                    return; // Don't initialize if no LARP ID is available
+        // Get the LARP ID from the data attribute or from the URL, if possible
+        if (!this.hasLarpValue) {
+            const match = window.location.pathname.match(/\/larp\/([^/]+)/);
+            if (match) {
+                this.larpValue = match[1];
+            } else {
+                // LARP ID not available - continue without mention search
+                this.larpValue = null;
             }
         }
-        this.searchUrl = this.searchUrlValue.replace('__larp__', this.larpValue);
+
+        if (this.larpValue) {
+            this.searchUrl = this.searchUrlValue.replace('__larp__', this.larpValue);
+        }
         this.editor = document.createElement('div');
         this.editor.classList.add('wysiwyg-editor');
         this.editor.contentEditable = true;

--- a/src/Form/CharacterType.php
+++ b/src/Form/CharacterType.php
@@ -40,6 +40,9 @@ class CharacterType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.character.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('availableForRecruitment', CheckboxType::class, [
                 'label' => 'form.character.available_for_recruitment',

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -34,6 +34,9 @@ class EventType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.event.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('place', EntityType::class, [
                 'class' => Place::class,

--- a/src/Form/FactionType.php
+++ b/src/Form/FactionType.php
@@ -22,6 +22,9 @@ class FactionType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.faction.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'form.submit',

--- a/src/Form/ItemType.php
+++ b/src/Form/ItemType.php
@@ -27,6 +27,9 @@ class ItemType extends AbstractType
             ->add('description', TextareaType::class, [
                 'label' => 'form.item.description',
                 'required' => false,
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('isCrafted', CheckboxType::class, [
                 'label' => 'form.item.is_crafted',

--- a/src/Form/KanbanTaskType.php
+++ b/src/Form/KanbanTaskType.php
@@ -21,6 +21,9 @@ class KanbanTaskType extends AbstractType
             ->add('description', TextareaType::class, [
                 'label' => 'form.kanban.description',
                 'required' => false,
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'form.submit',

--- a/src/Form/LarpIncidentType.php
+++ b/src/Form/LarpIncidentType.php
@@ -26,6 +26,9 @@ class LarpIncidentType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.incident.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('allowFeedback', CheckboxType::class, [
                 'label' => 'form.incident.allow_feedback',

--- a/src/Form/LarpType.php
+++ b/src/Form/LarpType.php
@@ -23,6 +23,9 @@ class LarpType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.larp.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('location', TextType::class, [
                 'label' => 'form.larp.location',

--- a/src/Form/LocationType.php
+++ b/src/Form/LocationType.php
@@ -25,7 +25,11 @@ class LocationType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,
-                'attr' => ['class' => 'form-control', 'rows' => 4]
+                'attr' => [
+                    'class' => 'form-control',
+                    'rows' => 4,
+                    'data-controller' => 'wysiwyg',
+                ]
             ])
             ->add('address', TextType::class, [
                 'attr' => ['class' => 'form-control']

--- a/src/Form/PlaceType.php
+++ b/src/Form/PlaceType.php
@@ -21,6 +21,9 @@ class PlaceType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.place.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'form.submit',

--- a/src/Form/QuestType.php
+++ b/src/Form/QuestType.php
@@ -34,6 +34,9 @@ class QuestType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.quest.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('thread', EntityType::class, [
                 'class' => Thread::class,

--- a/src/Form/RelationType.php
+++ b/src/Form/RelationType.php
@@ -38,6 +38,9 @@ class RelationType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'form.relation.description',
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('type', ChoiceType::class, [
                 'label' => 'form.relation.type',

--- a/src/Form/TagType.php
+++ b/src/Form/TagType.php
@@ -23,6 +23,9 @@ class TagType extends AbstractType
             ->add('description', TextareaType::class, [
                 'label' => 'form.tag.description',
                 'required' => false,
+                'attr' => [
+                    'data-controller' => 'wysiwyg',
+                ],
             ])
             ->add('target', ChoiceType::class, [
                 'label' => 'form.tag.target',


### PR DESCRIPTION
## Summary
- allow WYSIWYG editor to work without LARP id
- enable WYSIWYG controller on description fields across forms

## Testing
- `vendor/bin/ecs check --fix assets/controllers/wysiwyg_controller.js src/Form/CharacterType.php src/Form/EventType.php src/Form/FactionType.php src/Form/ItemType.php src/Form/KanbanTaskType.php src/Form/LarpIncidentType.php src/Form/LarpType.php src/Form/LocationType.php src/Form/PlaceType.php src/Form/QuestType.php src/Form/RelationType.php src/Form/TagType.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=256M` *(fails: Found 5 errors)*
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68755ba2121883268b7bd666e1e409c1