### PR TITLE
Add translations for user roles

### DIFF
--- a/src/Form/InvitationType.php
+++ b/src/Form/InvitationType.php
@@ -26,7 +26,8 @@ class InvitationType extends AbstractType
             ->add('invitedRole', ChoiceType::class, [
                 'label' => 'form.invitation.role',
                 'choices' => UserRole::cases(),
-                'choice_label' => fn (UserRole $role) => $role->name,
+                'choice_label' => fn (UserRole $role) => 'user_role.' . $role->value,
+                'choice_translation_domain' => 'messages',
                 'choice_value' => fn (?UserRole $role) => $role?->value,
                 'required' => true,
             ])

--- a/templates/backoffice/larp/invitation/list.html.twig
+++ b/templates/backoffice/larp/invitation/list.html.twig
@@ -32,7 +32,7 @@
                 {% else %}
                 {% for invitation in invitations %}
                     <tr>
-                        <td>{{ invitation.invitedRole.value }}</td>
+                        <td>{{ ('user_role.' ~ invitation.invitedRole.value)|trans }}</td>
                         <td>{{ invitation.validTo|date(constant('DateTimeInterface::ATOM')) }}</td>
                         <td>
 {#                            <a href="{{ path('backoffice_larp_invitations_modify', { larp: larp.id, invitation: invitation.id }) }}"#}

--- a/templates/public/larp/invitation_process.html.twig
+++ b/templates/public/larp/invitation_process.html.twig
@@ -11,7 +11,7 @@
 
                 <ul class="list-group list-group-flush my-4">
                     <li class="list-group-item">
-                        <strong>{{ 'common.role'|trans }}:</strong> {{ invitation.invitedRole.name }}
+                        <strong>{{ 'common.role'|trans }}:</strong> {{ ('user_role.' ~ invitation.invitedRole.value)|trans }}
                     </li>
                     {% if invitation.larpCharacter %}
                         <li class="list-group-item">

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -143,3 +143,23 @@ file_select:
 login_page:
   info: Wenn du bereits registriert bist, melde dich an und verbinde Konten in deinen Kontoeinstellungen.
   title: Registrierung / Anmeldung
+
+# Übersetzungen für Benutzerrollen
+user_role:
+  ROLE_ORGANIZER: 'Organisator'
+  ROLE_STAFF: 'Team'
+  ROLE_MAIN_STORY_WRITER: 'Hauptautor'
+  ROLE_STORY_WRITER: 'Autor'
+  ROLE_PHOTOGRAPHER: 'Fotograf'
+  ROLE_CRAFTER: 'Bastler'
+  ROLE_MAKEUP_ARTIST: 'Maskenbildner'
+  ROLE_GAME_MASTER: 'Spielleiter'
+  ROLE_NPC_LONG: 'NPC (lang)'
+  ROLE_NPC_SHORT: 'NPC (kurz)'
+  ROLE_PLAYER: 'Spieler'
+  ROLE_MEDIC: 'Sanitäter'
+  ROLE_TRASHER: 'Aufräumer'
+  ROLE_PERSON_OF_TRUST: 'Vertrauensperson'
+  ROLE_OUTFIT_APPROVER: 'Outfitprüfer'
+  ROLE_ACCOUNTANT: 'Buchhalter'
+  ROLE_GASTRO: 'Gastronomie'

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -362,3 +362,23 @@ larp:
   properties: 'Properties'
 form:
   character_choice: 'messages'
+
+# Role enumeration translations
+user_role:
+  ROLE_ORGANIZER: 'Organizer'
+  ROLE_STAFF: 'Staff'
+  ROLE_MAIN_STORY_WRITER: 'Main Story Writer'
+  ROLE_STORY_WRITER: 'Story Writer'
+  ROLE_PHOTOGRAPHER: 'Photographer'
+  ROLE_CRAFTER: 'Crafter'
+  ROLE_MAKEUP_ARTIST: 'Makeup Artist'
+  ROLE_GAME_MASTER: 'Game Master'
+  ROLE_NPC_LONG: 'NPC (Long)'
+  ROLE_NPC_SHORT: 'NPC (Short)'
+  ROLE_PLAYER: 'Player'
+  ROLE_MEDIC: 'Medic'
+  ROLE_TRASHER: 'Trasher'
+  ROLE_PERSON_OF_TRUST: 'Person of Trust'
+  ROLE_OUTFIT_APPROVER: 'Outfit Approver'
+  ROLE_ACCOUNTANT: 'Accountant'
+  ROLE_GASTRO: 'Gastronomy'

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -152,3 +152,23 @@ file_select:
 login_page:
   info: Jeśli już masz konto, zaloguj się i połącz konta w ustawieniach konta.
   title: Rejestracja / Logowanie
+
+# Tłumaczenia ról użytkownika
+user_role:
+  ROLE_ORGANIZER: 'Organizator'
+  ROLE_STAFF: 'Obsługa'
+  ROLE_MAIN_STORY_WRITER: 'Główny Pisarz Fabularny'
+  ROLE_STORY_WRITER: 'Pisarz Fabularny'
+  ROLE_PHOTOGRAPHER: 'Fotograf'
+  ROLE_CRAFTER: 'Rzemieślnik'
+  ROLE_MAKEUP_ARTIST: 'Charakteryzator'
+  ROLE_GAME_MASTER: 'Mistrz Gry'
+  ROLE_NPC_LONG: 'NPC (długoterminowy)'
+  ROLE_NPC_SHORT: 'NPC (krótkoterminowy)'
+  ROLE_PLAYER: 'Gracz'
+  ROLE_MEDIC: 'Medyk'
+  ROLE_TRASHER: 'Sprzątający'
+  ROLE_PERSON_OF_TRUST: 'Osoba zaufania'
+  ROLE_OUTFIT_APPROVER: 'Osoba zatwierdzająca stroje'
+  ROLE_ACCOUNTANT: 'Księgowy'
+  ROLE_GASTRO: 'Gastronomia'


### PR DESCRIPTION
## Summary
- translate user role enum values into en/de/pl
- use translated roles in invitation form and templates

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: Argument #4 must be of type App\Service\Larp\LarpApplicationDashboardService, App\Service\Larp\SubmissionStatsService given)*
- `vendor/bin/ecs check` *(fails: 36 errors are fixable)*
- `vendor/bin/phpstan analyse -c phpstan.neon` *(fails: process crashed due to memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_687aa90766108326bb261a1171623b3f