### PR TITLE
Standardize twig date format

### DIFF
--- a/templates/backoffice/larp/application/list.html.twig
+++ b/templates/backoffice/larp/application/list.html.twig
@@ -224,7 +224,7 @@
                                                     <span class="badge badge-info">{{ choice.character.title }}</span>
                                                 {% endfor %}
                                             </td>
-                                            <td>{{ application.createdAt|date('Y-m-d H:i') }}</td>
+                                            <td>{{ application.createdAt|date('Y-m-d H:m') }}</td>
                                             <td>
                                                 <a href="#" class="btn btn-sm btn-primary">{{ 'backoffice.larp.applications.view'|trans }}</a>
                                                 <a href="#" class="btn btn-sm btn-success">{{ 'backoffice.larp.applications.approve'|trans }}</a>

--- a/templates/backoffice/larp/details.html.twig
+++ b/templates/backoffice/larp/details.html.twig
@@ -170,9 +170,9 @@
                     <h6 class="card-title">{{ 'common.event.dates'|trans }}</h6>
                     <small class="text-muted">
                         {% if larp.startDate %}
-                            {{ larp.startDate|date('M d, Y') }}
+                            {{ larp.startDate|date('Y-m-d H:m') }}
                             {% if larp.endDate and larp.endDate != larp.startDate %}
-                                - {{ larp.endDate|date('M d, Y') }}
+                                - {{ larp.endDate|date('Y-m-d H:m') }}
                             {% endif %}
                         {% else %}
                             {{ 'common.not_set'|trans }}

--- a/templates/backoffice/larp/event/list.html.twig
+++ b/templates/backoffice/larp/event/list.html.twig
@@ -61,8 +61,8 @@
                 {% for event in events %}
                     <tr>
                         <td>{{ event.title }}</td>
-                        <td>{{ event.startTime ? event.startTime|date('Y-m-d H:i') : '-' }}</td>
-                        <td>{{ event.endTime ? event.endTime|date('Y-m-d H:i') : '-' }}</td>
+                        <td>{{ event.startTime ? event.startTime|date('Y-m-d H:m') : '-' }}</td>
+                        <td>{{ event.endTime ? event.endTime|date('Y-m-d H:m') : '-' }}</td>
                         <td>{{ event.description|sanitize_html|default('-') }}</td>
                         <td>
                             <a href="{{ path('backoffice_larp_story_event_modify', { larp: larp.id, event: event.id }) }}"

--- a/templates/backoffice/larp/invitation/list.html.twig
+++ b/templates/backoffice/larp/invitation/list.html.twig
@@ -33,7 +33,7 @@
                 {% for invitation in invitations %}
                     <tr>
                         <td>{{ ('user_role.' ~ invitation.invitedRole.value)|trans }}</td>
-                        <td>{{ invitation.validTo|date(constant('DateTimeInterface::ATOM')) }}</td>
+                        <td>{{ invitation.validTo|date('Y-m-d H:m') }}</td>
                         <td>
 {#                            <a href="{{ path('backoffice_larp_invitations_modify', { larp: larp.id, invitation: invitation.id }) }}"#}
 {#                               class="btn btn-sm btn-primary">#}

--- a/templates/backoffice/larp/kanban/_task_detail.html.twig
+++ b/templates/backoffice/larp/kanban/_task_detail.html.twig
@@ -30,13 +30,13 @@
         {% if task.dueDate %}
             <div class="meta-item">
                 <span class="meta-label">Due Date:</span>
-                <span class="meta-value">{{ task.dueDate|date('Y-m-d H:i') }}</span>
+                <span class="meta-value">{{ task.dueDate|date('Y-m-d H:m') }}</span>
             </div>
         {% endif %}
 
         <div class="meta-item">
             <span class="meta-label">Created:</span>
-            <span class="meta-value">{{ task.createdAt|date('Y-m-d H:i') }}</span>
+            <span class="meta-value">{{ task.createdAt|date('Y-m-d H:m') }}</span>
         </div>
     </div>
 

--- a/templates/backoffice/larp/kanban/board.html.twig
+++ b/templates/backoffice/larp/kanban/board.html.twig
@@ -69,7 +69,7 @@
 
                                         {% if task.dueDate %}
                                             <div class="task-due-date">
-                                                <i class="bi bi-clock"></i> Due: {{ task.dueDate|date('Y-m-d H:i') }}
+                                                <i class="bi bi-clock"></i> Due: {{ task.dueDate|date('Y-m-d H:m') }}
                                             </div>
                                         {% endif %}
                                     </li>

--- a/templates/backoffice/larp/list.html.twig
+++ b/templates/backoffice/larp/list.html.twig
@@ -9,7 +9,7 @@
                     <a href="{{ path('backoffice_larp_details', {'larp': larp.id}) }}" class="list-group-item list-group-item-action">
                         <div class="d-flex w-100 justify-content-between">
                             <div><small>{{ larp.status.value }}</small><h5 class="mb-1">{{ larp.title }}</h5></div>
-                            <small>{{ larp.startDate|date('Y-m-d') }}</small>
+                            <small>{{ larp.startDate|date('Y-m-d H:m') }}</small>
                         </div>
                         <p class="mb-1">{{ larp.description|sanitize_html|slice(0, 150) ~ '...'}}</p>
                         <small>{{ larp.location }}</small>

--- a/templates/components/StoryObjectVersionHistory.html.twig
+++ b/templates/components/StoryObjectVersionHistory.html.twig
@@ -3,7 +3,7 @@
     <ul class="list-unstyled">
         {% for item in this.getHistory() %}
             <li class="mb-3">
-                <strong>{{ item.entry.loggedAt|date('Y-m-d H:i') }} - {{ item.entry.username }}</strong>
+                <strong>{{ item.entry.loggedAt|date('Y-m-d H:m') }} - {{ item.entry.username }}</strong>
                 <ul>
                     {% for field, change in item.diff %}
                         <li>{{ field }}: {{ change.old }} -> {{ change.new }}</li>

--- a/templates/public/larp/_info_header.html.twig
+++ b/templates/public/larp/_info_header.html.twig
@@ -36,12 +36,12 @@
                             <li class="mb-2">
                                 <i class="bi bi-calendar-event text-muted me-2"></i>
                                 <strong>{{ 'common.start_date'|trans }}:</strong><br>
-                                <span class="ms-3">{{ larp.startDate|date('Y-m-d H:i') }}</span>
+                                <span class="ms-3">{{ larp.startDate|date('Y-m-d H:m') }}</span>
                             </li>
                             <li class="mb-2">
                                 <i class="bi bi-calendar-event text-muted me-2"></i>
                                 <strong>{{ 'common.end_date'|trans }}:</strong><br>
-                                <span class="ms-3">{{ larp.endDate|date('Y-m-d H:i') }}</span>
+                                <span class="ms-3">{{ larp.endDate|date('Y-m-d H:m') }}</span>
                             </li>
                             <li>
                                 <i class="bi bi-info-circle text-muted me-2"></i>

--- a/templates/public/larp/invitation_process.html.twig
+++ b/templates/public/larp/invitation_process.html.twig
@@ -19,7 +19,7 @@
                         </li>
                     {% endif %}
                     <li class="list-group-item">
-                        <strong>{{ 'common.valid_until'|trans }}:</strong> {{ invitation.validTo|date('Y-m-d H:i') }}
+                        <strong>{{ 'common.valid_until'|trans }}:</strong> {{ invitation.validTo|date('Y-m-d H:m') }}
                     </li>
                 </ul>
 

--- a/templates/public/larp/list.html.twig
+++ b/templates/public/larp/list.html.twig
@@ -49,7 +49,7 @@
                                 {% endif %}
 
                                 <div class="mb-2">
-                                    <strong>Date:</strong> {{ larp.startDate|date('Y-m-d') }} - {{ larp.endDate|date('Y-m-d') }}
+                                    <strong>Date:</strong> {{ larp.startDate|date('Y-m-d H:m') }} - {{ larp.endDate|date('Y-m-d H:m') }}
                                 </div>
 
                                 <div class="mb-2">


### PR DESCRIPTION
## Summary
- standardize all Twig date formats to `Y-m-d H:m`

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: The file app.output.css doesn't exist)*
- `vendor/bin/ecs check` *(fails: fixable coding standard errors)*
- `vendor/bin/phpstan analyse -c phpstan.neon`

------
https://chatgpt.com/codex/tasks/task_e_687b5245a198832690c4c88ef0389e2b