### PR TITLE
Add participant view for assigned characters

### DIFF
--- a/src/Domain/Core/Controller/Public/LarpController.php
+++ b/src/Domain/Core/Controller/Public/LarpController.php
@@ -6,12 +6,14 @@ use App\Domain\Application\Repository\LarpApplicationRepository;
 use App\Domain\Core\Controller\BaseController;
 use App\Domain\Core\Form\Filter\LarpPublicFilterType;
 use App\Domain\Core\Repository\LarpInvitationRepository;
+use App\Domain\Core\Repository\LarpParticipantRepository;
 use App\Domain\Core\Repository\LarpRepository;
 use App\Domain\Core\Service\LarpManager;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/', name: 'public_larp_')]
 class LarpController extends BaseController
@@ -34,6 +36,23 @@ class LarpController extends BaseController
         return $this->render('public/larp/list.html.twig', [
             'larps' => $pagination,
             'filterForm' => $filterForm->createView(),
+        ]);
+    }
+
+    #[Route('/my/larps', name: 'my_larps', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function myLarps(LarpParticipantRepository $participantRepository): Response
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof UserInterface) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $participants = $participantRepository->findForUserWithCharacters($user);
+
+        return $this->render('public/larp/my_larps.html.twig', [
+            'participants' => $participants,
         ]);
     }
 

--- a/src/Domain/Core/Repository/LarpParticipantRepository.php
+++ b/src/Domain/Core/Repository/LarpParticipantRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Core\Repository;
 
+use App\Domain\Account\Entity\User;
 use App\Domain\Core\Entity\LarpParticipant;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -19,5 +20,23 @@ class LarpParticipantRepository extends BaseRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, LarpParticipant::class);
+    }
+
+    /**
+     * @return LarpParticipant[]
+     */
+    public function findForUserWithCharacters(User $user): array
+    {
+        return $this->createQueryBuilder('participant')
+            ->addSelect('larp', 'characters')
+            ->join('participant.larp', 'larp')
+            ->leftJoin('participant.larpCharacters', 'characters')
+            ->where('participant.user = :user')
+            ->setParameter('user', $user)
+            ->orderBy('larp.startDate', 'DESC')
+            ->addOrderBy('larp.title', 'ASC')
+            ->addOrderBy('characters.title', 'ASC')
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/src/Twig/MenuExtension.php
+++ b/src/Twig/MenuExtension.php
@@ -40,6 +40,10 @@ class MenuExtension extends AbstractExtension implements GlobalsInterface
                         'url' => $this->router->generate('account_settings'),
                     ],
                     [
+                        'label' => $this->translator->trans('account.my_larps'),
+                        'url' => $this->router->generate('public_larp_my_larps'),
+                    ],
+                    [
                         'label' => $this->translator->trans('account.connected_accounts'),
                         'url' => $this->router->generate('account_social_accounts'),
                     ],

--- a/templates/public/larp/my_larps.html.twig
+++ b/templates/public/larp/my_larps.html.twig
@@ -1,0 +1,74 @@
+{% extends 'public/base.html.twig' %}
+
+{% block title %}
+    {{ 'public.participant.my_larps.title'|trans }}
+{% endblock %}
+
+{% block body %}
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <h1 class="mb-4">{{ 'public.participant.my_larps.title'|trans }}</h1>
+
+                {% if participants is empty %}
+                    <div class="alert alert-info text-center">
+                        <i class="bi bi-info-circle me-2"></i>{{ 'public.participant.my_larps.empty'|trans }}
+                    </div>
+                {% else %}
+                    {% for participant in participants %}
+                        <div class="card shadow-sm mb-4">
+                            <div class="card-header d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center">
+                                <div>
+                                    <h2 class="h5 mb-1">{{ participant.larp.title }}</h2>
+                                    <div class="text-muted small">
+                                        <i class="bi bi-calendar3 me-1"></i>
+                                        {% if participant.larp.startDate %}
+                                            {{ participant.larp.startDate|date('F j, Y') }}
+                                        {% else %}
+                                            &mdash;
+                                        {% endif %}
+                                        {% if participant.larp.endDate %}
+                                            <span class="mx-1">&bull;</span>
+                                            {{ participant.larp.endDate|date('F j, Y') }}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                <a href="{{ path('public_larp_details', {'slug': participant.larp.slug}) }}"
+                                   class="btn btn-outline-primary btn-sm mt-3 mt-md-0">
+                                    <i class="bi bi-eye me-1"></i>{{ 'public.participant.my_larps.view_public_page'|trans }}
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                {% if participant.larpCharacters is empty %}
+                                    <div class="alert alert-secondary mb-0">
+                                        <i class="bi bi-hourglass-split me-2"></i>{{ 'public.participant.my_larps.no_characters'|trans }}
+                                    </div>
+                                {% else %}
+                                    <div class="list-group list-group-flush">
+                                        {% for character in participant.larpCharacters %}
+                                            <div class="list-group-item px-0">
+                                                <h3 class="h5 mb-1">
+                                                    <i class="bi bi-person-fill me-2 text-primary"></i>{{ character.title }}
+                                                </h3>
+                                                {% if character.inGameName %}
+                                                    <p class="mb-1 text-muted">
+                                                        <i class="bi bi-person-badge me-2"></i>{{ character.inGameName }}
+                                                    </p>
+                                                {% endif %}
+                                                {% if character.description %}
+                                                    <div class="text-muted small">
+                                                        {{ character.description|sanitize_html }}
+                                                    </div>
+                                                {% endif %}
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -509,6 +509,7 @@ account:
   larp:
     list: Your LARPs
   settings: "Settings"
+  my_larps: 'My LARPs'
   connected_accounts: "Connected Accounts list"
   no_connected_accounts: "You have not linked any social accounts yet."
   link_another_social: "Link Another Social Account"
@@ -536,6 +537,14 @@ success_save: "Successfully saved changes"
 success_delete: "Successfully removed"
 confirmation: "Are you sure you want to proceed? This action cannot be undone."
 votes: "Votes"
+
+public:
+  participant:
+    my_larps:
+      title: 'My LARPs & Characters'
+      empty: 'You have not been assigned any characters yet.'
+      view_public_page: 'View public page'
+      no_characters: 'No characters have been assigned to you yet.'
 
 character_type:
   player: "Player"

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -509,6 +509,7 @@ account:
   larp:
     list: Twoje LARPy
   settings: "Ustawienia"
+  my_larps: 'Moje LARPy'
   connected_accounts: "Lista połączonych kont"
   no_connected_accounts: "Nie połączyłeś jeszcze żadnych kont społecznościowych."
   link_another_social: "Połącz inne konto społecznościowe"
@@ -536,6 +537,14 @@ success_save: "Pomyślnie zapisano zmiany"
 success_delete: "Pomyślnie usunięto"
 confirmation: "Czy na pewno chcesz kontynuować? Tej akcji nie można cofnąć."
 votes: "Głosy"
+
+public:
+  participant:
+    my_larps:
+      title: 'Moje LARPy i postacie'
+      empty: 'Nie masz jeszcze przypisanych żadnych postaci.'
+      view_public_page: 'Zobacz stronę publiczną'
+      no_characters: 'Brak przypisanych postaci.'
 
 character_type:
   player: "Gracz"


### PR DESCRIPTION
## Summary
- add a repository helper to load a participant's LARPs together with assigned characters
- expose a public "My LARPs" page for logged-in participants and link it from the menu
- add translations for the new participant view in English and Polish

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900cb7ae1a0832686a434416e5b0efc